### PR TITLE
include: Load platform depended macros

### DIFF
--- a/include/plugin.h
+++ b/include/plugin.h
@@ -25,6 +25,7 @@
 #ifndef LITE_OBS
 #include "obs-module.h"
 #include "util/base.h"
+#include "util/platform.h"
 #endif
 #pragma warning(pop)
 


### PR DESCRIPTION
"snprintf" is macro in OBS Studio.