### PR TITLE
H264, H265: Switch order for Resolution, FrameRate, Profile and Level

### DIFF
--- a/source/enc-h264.cpp
+++ b/source/enc-h264.cpp
@@ -1313,16 +1313,17 @@ Plugin::Interface::H264Interface::H264Interface(obs_data_t* data, obs_encoder_t*
 		(size_t)obs_data_get_int(data, P_QUEUESIZE));
 
 	/// Static Properties
+	m_VideoEncoder->SetUsage(Plugin::AMD::Usage::Transcoding);
 	m_VideoEncoder->SetQualityPreset(static_cast<QualityPreset>(obs_data_get_int(data, P_QUALITYPRESET)));
+
+	/// Frame
+	m_VideoEncoder->SetResolution(std::make_pair(obsWidth, obsHeight));
+	m_VideoEncoder->SetFrameRate(std::make_pair(obsFPSnum, obsFPSden));
 
 	/// Profile & Level
 	m_VideoEncoder->SetProfile(static_cast<Profile>(obs_data_get_int(data, P_PROFILE)));
 	m_VideoEncoder->SetProfileLevel(static_cast<ProfileLevel>(obs_data_get_int(data, P_PROFILELEVEL)),
 									std::make_pair(obsWidth, obsHeight), std::make_pair(obsFPSnum, obsFPSden));
-
-	/// Frame
-	m_VideoEncoder->SetResolution(std::make_pair(obsWidth, obsHeight));
-	m_VideoEncoder->SetFrameRate(std::make_pair(obsFPSnum, obsFPSden));
 
 	try {
 		m_VideoEncoder->SetCodingType(static_cast<CodingType>(obs_data_get_int(data, P_CODINGTYPE)));

--- a/source/enc-h265.cpp
+++ b/source/enc-h265.cpp
@@ -892,8 +892,12 @@ Plugin::Interface::H265Interface::H265Interface(obs_data_t* data, obs_encoder_t*
 		(size_t)obs_data_get_int(data, P_QUEUESIZE));
 
 	/// Static Properties
-	//m_VideoEncoder->SetUsage(Usage::Transcoding);
+	m_VideoEncoder->SetUsage(Plugin::AMD::Usage::Transcoding);
 	m_VideoEncoder->SetQualityPreset(static_cast<QualityPreset>(obs_data_get_int(data, P_QUALITYPRESET)));
+
+	/// Frame
+	m_VideoEncoder->SetResolution(std::make_pair(obsWidth, obsHeight));
+	m_VideoEncoder->SetFrameRate(std::make_pair(obsFPSnum, obsFPSden));
 
 	/// Profile & Level
 	m_VideoEncoder->SetProfile(static_cast<Profile>(obs_data_get_int(data, P_PROFILE)));
@@ -901,9 +905,6 @@ Plugin::Interface::H265Interface::H265Interface(obs_data_t* data, obs_encoder_t*
 									std::make_pair(obsWidth, obsHeight), std::make_pair(obsFPSnum, obsFPSden));
 	m_VideoEncoder->SetTier(static_cast<H265::Tier>(obs_data_get_int(data, P_TIER)));
 
-	/// Frame
-	m_VideoEncoder->SetResolution(std::make_pair(obsWidth, obsHeight));
-	m_VideoEncoder->SetFrameRate(std::make_pair(obsFPSnum, obsFPSden));
 	///- Aspect Ratio
 
 	try {


### PR DESCRIPTION
Recent AMD Drivers (19.x) have restricted Profile and Level to only be applicable to the correct Resolution and FrameRate. While this is technically backwards from the way it is supposed to be (Profile and Level restrict Resolution and FrameRate) this is the choice AMD made and it needs to be fixed in the plugin.

It is unknown if this introduces backwards incompatibility with older drivers.

Fixes #345 