### PR TITLE
H264, H265: Ignore unsupported Levels in Automatic mode

### DIFF
--- a/source/amf-encoder-h265.cpp
+++ b/source/amf-encoder-h265.cpp
@@ -324,16 +324,7 @@ std::vector<ProfileLevel> Plugin::AMD::EncoderH265::CapsProfileLevel()
 void Plugin::AMD::EncoderH265::SetProfileLevel(ProfileLevel v)
 {
 	AMFTRACECALL;
-
-	if (v == ProfileLevel::Automatic)
-		v = Utility::H265ProfileLevel(m_Resolution, m_FrameRate);
-
-	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PROFILE_LEVEL, ((int64_t)v) * 3);
-	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %lld, error %ls (code %d)",
-							 m_UniqueId, (int64_t)v, m_AMF->GetTrace()->GetResultText(res), res);
-		throw std::exception(errMsg.c_str());
-	}
+	SetProfileLevel(v, m_Resolution, m_FrameRate);
 }
 
 void Plugin::AMD::EncoderH265::SetProfileLevel(ProfileLevel v, std::pair<uint32_t, uint32_t> r,
@@ -343,6 +334,19 @@ void Plugin::AMD::EncoderH265::SetProfileLevel(ProfileLevel v, std::pair<uint32_
 
 	if (v == ProfileLevel::Automatic)
 		v = Utility::H265ProfileLevel(r, h);
+
+	bool         supported       = false;
+	ProfileLevel supported_level = v;
+	for (auto k : CapsProfileLevel()) {
+		if (k == supported_level) {
+			supported = true;
+			break;
+		}
+		if (k > v && !supported) {
+			v = k;
+			break;
+		}
+	}
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PROFILE_LEVEL, ((int64_t)v) * 3);
 	if (res != AMF_OK) {


### PR DESCRIPTION
Fixes the unsupported Profile Level bug by picking the next higher supported Profile Level, if possible. If there is none, no change will be applied.