### PR TITLE
Fix __FUNCTION_NAME__ usages to be standard compliant

### DIFF
--- a/include/amf-encoder.hpp
+++ b/include/amf-encoder.hpp
@@ -66,7 +66,7 @@ extern "C" {
 		std::vector<wchar_t> buf2(std::mbsrtowcs(NULL, &fname, 0, &state) + 1);                          \
 		std::mbsrtowcs(buf2.data(), &fname, buf2.size(), &state);                                        \
 		trace->TraceW(buf.data(), __LINE__, AMF_TRACE_DEBUG, L"Trace", 1, L"Function: %s", buf2.data()); \
-		PLOG_DEBUG("<Trace> " __FUNCTION_NAME__);                                                        \
+		PLOG_DEBUG("<Trace> %s", __FUNCTION_NAME__);                                                     \
 	};
 #else
 #define AMFTRACECALL ;

--- a/source/amf-encoder-h264.cpp
+++ b/source/amf-encoder-h264.cpp
@@ -66,8 +66,8 @@ std::vector<Usage> Plugin::AMD::EncoderH264::CapsUsage()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_USAGE, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -84,8 +84,8 @@ void Plugin::AMD::EncoderH264::SetUsage(Usage v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_USAGE, Utility::UsageToAMFH264(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::UsageToString(v), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::UsageToString(v), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -98,8 +98,8 @@ Plugin::AMD::Usage Plugin::AMD::EncoderH264::GetUsage()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_USAGE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return Utility::UsageFromAMFH264((AMF_VIDEO_ENCODER_USAGE_ENUM)e);
@@ -113,8 +113,8 @@ std::vector<QualityPreset> Plugin::AMD::EncoderH264::CapsQualityPreset()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_QUALITY_PRESET, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -131,8 +131,8 @@ void Plugin::AMD::EncoderH264::SetQualityPreset(QualityPreset v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_QUALITY_PRESET, Utility::QualityPresetToAMFH264(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::QualityPresetToString(v), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::QualityPresetToString(v), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -145,8 +145,8 @@ Plugin::AMD::QualityPreset Plugin::AMD::EncoderH264::GetQualityPreset()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_QUALITY_PRESET, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return Utility::QualityPresetFromAMFH264((AMF_VIDEO_ENCODER_QUALITY_PRESET_ENUM)e);
@@ -160,8 +160,8 @@ std::vector<Profile> Plugin::AMD::EncoderH264::CapsProfile()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_PROFILE, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -178,8 +178,8 @@ void Plugin::AMD::EncoderH264::SetProfile(Profile v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_PROFILE, Utility::ProfileToAMFH264(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::ProfileToString(v), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::ProfileToString(v), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -192,8 +192,8 @@ Plugin::AMD::Profile Plugin::AMD::EncoderH264::GetProfile()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_PROFILE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return Utility::ProfileFromAMFH264((AMF_VIDEO_ENCODER_PROFILE_ENUM)e);
@@ -206,8 +206,8 @@ std::vector<ProfileLevel> Plugin::AMD::EncoderH264::CapsProfileLevel()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_PROFILE_LEVEL, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -247,8 +247,8 @@ void Plugin::AMD::EncoderH264::SetProfileLevel(ProfileLevel v, std::pair<uint32_
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_PROFILE_LEVEL, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %lld, error %ls (code %d)",
-							 m_UniqueId, (int64_t)v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %lld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, (int64_t)v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -261,8 +261,8 @@ Plugin::AMD::ProfileLevel Plugin::AMD::EncoderH264::GetProfileLevel()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_PROFILE_LEVEL, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (ProfileLevel)e;
@@ -275,8 +275,8 @@ std::pair<uint64_t, uint64_t> Plugin::AMD::EncoderH264::CapsMaximumReferenceFram
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_MAX_NUM_REFRAMES, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -289,8 +289,8 @@ void Plugin::AMD::EncoderH264::SetMaximumReferenceFrames(uint64_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_MAX_NUM_REFRAMES, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %lld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %lld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -304,8 +304,8 @@ uint64_t Plugin::AMD::EncoderH264::GetMaximumReferenceFrames()
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_MAX_NUM_REFRAMES, &e);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(
-			errMsg, __FUNCTION_NAME__ PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-			m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+			errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+			m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -318,8 +318,8 @@ std::pair<std::pair<uint32_t, uint32_t>, std::pair<uint32_t, uint32_t>> Plugin::
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_FRAMESIZE, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -333,8 +333,8 @@ void Plugin::AMD::EncoderH264::SetResolution(std::pair<uint32_t, uint32_t> v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_FRAMESIZE, ::AMFConstructSize(v.first, v.second));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %ldx%ld, error %ls (code %d)",
-							 m_UniqueId, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %ldx%ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	m_Resolution.first  = v.first;
@@ -349,8 +349,8 @@ std::pair<uint32_t, uint32_t> Plugin::AMD::EncoderH264::GetResolution()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_FRAMESIZE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	m_Resolution.first  = e.width;
@@ -364,8 +364,8 @@ void Plugin::AMD::EncoderH264::SetAspectRatio(std::pair<uint32_t, uint32_t> v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_ASPECT_RATIO, ::AMFConstructRatio(v.first, v.second));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %ld:%ld, error %ls (code %d)",
-							 m_UniqueId, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %ld:%ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -378,8 +378,8 @@ std::pair<uint32_t, uint32_t> Plugin::AMD::EncoderH264::GetAspectRatio()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_ASPECT_RATIO, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return std::make_pair(e.num, e.den);
@@ -391,8 +391,8 @@ void Plugin::AMD::EncoderH264::SetFrameRate(std::pair<uint32_t, uint32_t> v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_FRAMERATE, ::AMFConstructRate(v.first, v.second));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %ld/%ld, error %ls (code %d)",
-							 m_UniqueId, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %ld/%ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	m_FrameRate = std::make_pair(v.first, v.second);
@@ -423,8 +423,8 @@ std::vector<CodingType> Plugin::AMD::EncoderH264::CapsCodingType()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_CABAC_ENABLE, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -441,8 +441,8 @@ void Plugin::AMD::EncoderH264::SetCodingType(CodingType v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_CABAC_ENABLE, Utility::CodingTypeToAMFH264(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::CodingTypeToString(v), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::CodingTypeToString(v), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -469,8 +469,8 @@ std::pair<uint32_t, uint32_t> Plugin::AMD::EncoderH264::CapsMaximumLongTermRefer
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_MAX_LTR_FRAMES, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -483,8 +483,8 @@ void Plugin::AMD::EncoderH264::SetMaximumLongTermReferenceFrames(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_MAX_LTR_FRAMES, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -496,8 +496,8 @@ uint32_t Plugin::AMD::EncoderH264::GetMaximumLongTermReferenceFrames()
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_MAX_LTR_FRAMES, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint32_t)e;
@@ -511,8 +511,8 @@ std::vector<RateControlMethod> Plugin::AMD::EncoderH264::CapsRateControlMethod()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -530,8 +530,8 @@ void Plugin::AMD::EncoderH264::SetRateControlMethod(RateControlMethod v)
 	AMF_RESULT res =
 		m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD, Utility::RateControlMethodToAMFH264(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::RateControlMethodToString(v), m_AMF->GetTrace()->GetResultText(res),
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::RateControlMethodToString(v), m_AMF->GetTrace()->GetResultText(res),
 							 res);
 		throw std::exception(errMsg.c_str());
 	}
@@ -545,8 +545,8 @@ Plugin::AMD::RateControlMethod Plugin::AMD::EncoderH264::GetRateControlMethod()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return Utility::RateControlMethodFromAMFH264((AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_ENUM)e);
@@ -559,8 +559,8 @@ std::vector<PrePassMode> Plugin::AMD::EncoderH264::CapsPrePassMode()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_RATE_CONTROL_PREANALYSIS_ENABLE, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -578,8 +578,8 @@ void Plugin::AMD::EncoderH264::SetPrePassMode(PrePassMode v)
 	AMF_RESULT res =
 		m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_RATE_CONTROL_PREANALYSIS_ENABLE, Utility::PrePassModeToAMFH264(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::PrePassModeToString(v), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::PrePassModeToString(v), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -605,8 +605,8 @@ void Plugin::AMD::EncoderH264::SetVarianceBasedAdaptiveQuantizationEnabled(bool 
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_ENABLE_VBAQ, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -619,8 +619,8 @@ bool Plugin::AMD::EncoderH264::IsVarianceBasedAdaptiveQuantizationEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_ENABLE_VBAQ, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -632,8 +632,8 @@ void Plugin::AMD::EncoderH264::SetFrameSkippingEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_RATE_CONTROL_SKIP_FRAME_ENABLE, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -646,8 +646,8 @@ bool Plugin::AMD::EncoderH264::IsFrameSkippingEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_RATE_CONTROL_SKIP_FRAME_ENABLE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -659,8 +659,8 @@ void Plugin::AMD::EncoderH264::SetEnforceHRDEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_ENFORCE_HRD, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -673,8 +673,8 @@ bool Plugin::AMD::EncoderH264::IsEnforceHRDEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_ENFORCE_HRD, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -686,8 +686,8 @@ void Plugin::AMD::EncoderH264::SetFillerDataEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_FILLER_DATA_ENABLE, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -700,8 +700,8 @@ bool Plugin::AMD::EncoderH264::IsFillerDataEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_FILLER_DATA_ENABLE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -715,8 +715,8 @@ std::pair<uint8_t, uint8_t> Plugin::AMD::EncoderH264::CapsQPMinimum()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_MIN_QP, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -729,8 +729,8 @@ void Plugin::AMD::EncoderH264::SetQPMinimum(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_MIN_QP, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -743,8 +743,8 @@ uint8_t Plugin::AMD::EncoderH264::GetQPMinimum()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_MIN_QP, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -758,8 +758,8 @@ std::pair<uint8_t, uint8_t> Plugin::AMD::EncoderH264::CapsQPMaximum()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_MAX_QP, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -772,8 +772,8 @@ void Plugin::AMD::EncoderH264::SetQPMaximum(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_MAX_QP, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -786,8 +786,8 @@ uint8_t Plugin::AMD::EncoderH264::GetQPMaximum()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_MAX_QP, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -800,8 +800,8 @@ std::pair<uint64_t, uint64_t> Plugin::AMD::EncoderH264::CapsTargetBitrate()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_TARGET_BITRATE, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -814,8 +814,8 @@ void Plugin::AMD::EncoderH264::SetTargetBitrate(uint64_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_TARGET_BITRATE, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %lld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %lld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -828,8 +828,8 @@ uint64_t Plugin::AMD::EncoderH264::GetTargetBitrate()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_TARGET_BITRATE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -842,8 +842,8 @@ std::pair<uint64_t, uint64_t> Plugin::AMD::EncoderH264::CapsPeakBitrate()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_PEAK_BITRATE, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -856,8 +856,8 @@ void Plugin::AMD::EncoderH264::SetPeakBitrate(uint64_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_PEAK_BITRATE, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %lld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %lld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -870,8 +870,8 @@ uint64_t Plugin::AMD::EncoderH264::GetPeakBitrate()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_PEAK_BITRATE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -885,8 +885,8 @@ std::pair<uint8_t, uint8_t> Plugin::AMD::EncoderH264::CapsIFrameQP()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_QP_I, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -899,8 +899,8 @@ void Plugin::AMD::EncoderH264::SetIFrameQP(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_QP_I, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -913,8 +913,8 @@ uint8_t Plugin::AMD::EncoderH264::GetIFrameQP()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_QP_I, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -928,8 +928,8 @@ std::pair<uint8_t, uint8_t> Plugin::AMD::EncoderH264::CapsPFrameQP()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_QP_P, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -942,8 +942,8 @@ void Plugin::AMD::EncoderH264::SetPFrameQP(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_QP_P, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -956,8 +956,8 @@ uint8_t Plugin::AMD::EncoderH264::GetPFrameQP()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_QP_P, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -971,8 +971,8 @@ std::pair<uint8_t, uint8_t> Plugin::AMD::EncoderH264::CapsBFrameQP()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_QP_B, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -985,8 +985,8 @@ void Plugin::AMD::EncoderH264::SetBFrameQP(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_QP_B, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -999,8 +999,8 @@ uint8_t Plugin::AMD::EncoderH264::GetBFrameQP()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_QP_B, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -1012,8 +1012,8 @@ void Plugin::AMD::EncoderH264::SetMaximumAccessUnitSize(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_MAX_AU_SIZE, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1025,8 +1025,8 @@ uint32_t Plugin::AMD::EncoderH264::GetMaximumAccessUnitSize()
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_MAX_AU_SIZE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint32_t)e;
@@ -1039,8 +1039,8 @@ std::pair<uint64_t, uint64_t> Plugin::AMD::EncoderH264::CapsVBVBufferSize()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1053,8 +1053,8 @@ void Plugin::AMD::EncoderH264::SetVBVBufferSize(uint64_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %lld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %lld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1067,8 +1067,8 @@ uint64_t Plugin::AMD::EncoderH264::GetVBVBufferSize()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1080,8 +1080,8 @@ void Plugin::AMD::EncoderH264::SetVBVBufferInitialFullness(double v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_INITIAL_VBV_BUFFER_FULLNESS, (int64_t)(v * 64));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %lf (%d), error %ls (code %d)",
-							 m_UniqueId, v, (uint8_t)(v * 64), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %lf (%d), error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, (uint8_t)(v * 64), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1094,8 +1094,8 @@ float Plugin::AMD::EncoderH264::GetInitialVBVBufferFullness()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_INITIAL_VBV_BUFFER_FULLNESS, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (e / 64.0f);
@@ -1108,8 +1108,8 @@ void Plugin::AMD::EncoderH264::SetIDRPeriod(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, (int64_t)clamp(v, 1, 1000000));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	m_PeriodIDR = v;
@@ -1123,8 +1123,8 @@ uint32_t Plugin::AMD::EncoderH264::GetIDRPeriod()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	m_PeriodIDR = (uint32_t)e;
@@ -1137,8 +1137,8 @@ void Plugin::AMD::EncoderH264::SetHeaderInsertionSpacing(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEADER_INSERTION_SPACING, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1151,8 +1151,8 @@ uint32_t Plugin::AMD::EncoderH264::GetHeaderInsertionSpacing()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEADER_INSERTION_SPACING, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint32_t)e;
@@ -1164,8 +1164,8 @@ void Plugin::AMD::EncoderH264::SetGOPAlignmentEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(L"EnableGOPAlignment", v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1177,8 +1177,8 @@ bool Plugin::AMD::EncoderH264::IsGOPAlignmentEnabled()
 	bool       e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(L"EnableGOPAlignment", &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1190,8 +1190,8 @@ void Plugin::AMD::EncoderH264::SetDeblockingFilterEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_DE_BLOCKING_FILTER, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1204,8 +1204,8 @@ bool Plugin::AMD::EncoderH264::IsDeblockingFilterEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_DE_BLOCKING_FILTER, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1218,8 +1218,8 @@ uint8_t Plugin::AMD::EncoderH264::CapsBFramePattern()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_B_PIC_PATTERN, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1232,8 +1232,8 @@ void Plugin::AMD::EncoderH264::SetBFramePattern(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_B_PIC_PATTERN, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	m_TimestampOffset = v;
@@ -1247,8 +1247,8 @@ uint8_t Plugin::AMD::EncoderH264::GetBFramePattern()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_B_PIC_PATTERN, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -1260,8 +1260,8 @@ void Plugin::AMD::EncoderH264::SetBFrameDeltaQP(int8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_QP_B, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1274,8 +1274,8 @@ int8_t Plugin::AMD::EncoderH264::GetBFrameDeltaQP()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_B_PIC_DELTA_QP, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (int8_t)e;
@@ -1287,8 +1287,8 @@ void Plugin::AMD::EncoderH264::SetBFrameReferenceEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_B_REFERENCE_ENABLE, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1301,8 +1301,8 @@ bool Plugin::AMD::EncoderH264::IsBFrameReferenceEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_B_REFERENCE_ENABLE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1314,8 +1314,8 @@ void Plugin::AMD::EncoderH264::SetBFrameReferenceDeltaQP(int8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_REF_B_PIC_DELTA_QP, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1328,8 +1328,8 @@ int8_t Plugin::AMD::EncoderH264::GetBFrameReferenceDeltaQP()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_REF_B_PIC_DELTA_QP, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (int8_t)e;
@@ -1342,8 +1342,8 @@ void Plugin::AMD::EncoderH264::SetMotionEstimationQuarterPixelEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_MOTION_HALF_PIXEL, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set mode to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set mode to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1356,8 +1356,8 @@ bool Plugin::AMD::EncoderH264::IsMotionEstimationQuarterPixelEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_MOTION_HALF_PIXEL, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1369,8 +1369,8 @@ void Plugin::AMD::EncoderH264::SetMotionEstimationHalfPixelEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_MOTION_QUARTERPIXEL, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set mode to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set mode to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1383,8 +1383,8 @@ bool Plugin::AMD::EncoderH264::IsMotionEstimationHalfPixelEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_MOTION_QUARTERPIXEL, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1398,8 +1398,8 @@ std::pair<uint32_t, uint32_t> Plugin::AMD::EncoderH264::CapsIntraRefreshNumMBsPe
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_INTRA_REFRESH_NUM_MBS_PER_SLOT, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1412,8 +1412,8 @@ void Plugin::AMD::EncoderH264::SetIntraRefreshNumMBsPerSlot(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_INTRA_REFRESH_NUM_MBS_PER_SLOT, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1426,8 +1426,8 @@ uint32_t Plugin::AMD::EncoderH264::GetIntraRefreshNumMBsPerSlot()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_INTRA_REFRESH_NUM_MBS_PER_SLOT, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint32_t)e;
@@ -1439,8 +1439,8 @@ void Plugin::AMD::EncoderH264::SetIntraRefreshNumOfStripes(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(L"IntraRefreshNumOfStripes", (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1452,8 +1452,8 @@ uint32_t Plugin::AMD::EncoderH264::GetIntraRefreshNumOfStripes()
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(L"IntraRefreshNumOfStripes", &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint32_t)e;

--- a/source/amf-encoder-h265.cpp
+++ b/source/amf-encoder-h265.cpp
@@ -58,8 +58,8 @@ std::vector<Usage> Plugin::AMD::EncoderH265::CapsUsage()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_USAGE, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -76,8 +76,8 @@ void Plugin::AMD::EncoderH265::SetUsage(Usage v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_USAGE, Utility::UsageToAMFH265(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::UsageToString(v), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::UsageToString(v), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -90,8 +90,8 @@ Plugin::AMD::Usage Plugin::AMD::EncoderH265::GetUsage()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_USAGE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return Utility::UsageFromAMFH265((AMF_VIDEO_ENCODER_HEVC_USAGE_ENUM)e);
@@ -106,8 +106,8 @@ std::vector<QualityPreset> Plugin::AMD::EncoderH265::CapsQualityPreset()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -125,8 +125,8 @@ void Plugin::AMD::EncoderH265::SetQualityPreset(QualityPreset v)
 	AMF_RESULT res =
 		m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET, Utility::QualityPresetToAMFH265(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::QualityPresetToString(v), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::QualityPresetToString(v), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -139,8 +139,8 @@ Plugin::AMD::QualityPreset Plugin::AMD::EncoderH265::GetQualityPreset()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return Utility::QualityPresetFromAMFH265((AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_ENUM)e);
@@ -155,8 +155,8 @@ std::pair<std::pair<uint32_t, uint32_t>, std::pair<uint32_t, uint32_t>> Plugin::
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_FRAMESIZE, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -170,8 +170,8 @@ void Plugin::AMD::EncoderH265::SetResolution(std::pair<uint32_t, uint32_t> v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_FRAMESIZE, ::AMFConstructSize(v.first, v.second));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %ldx%ld, error %ls (code %d)",
-							 m_UniqueId, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %ldx%ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	m_Resolution.first  = v.first;
@@ -186,8 +186,8 @@ std::pair<uint32_t, uint32_t> Plugin::AMD::EncoderH265::GetResolution()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_FRAMESIZE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	m_Resolution.first  = e.width;
@@ -202,8 +202,8 @@ void Plugin::AMD::EncoderH265::SetAspectRatio(std::pair<uint32_t, uint32_t> v)
 	AMF_RESULT res =
 		m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ASPECT_RATIO, ::AMFConstructRatio(v.first, v.second));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %ld:%ld, error %ls (code %d)",
-							 m_UniqueId, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %ld:%ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -216,8 +216,8 @@ std::pair<uint32_t, uint32_t> Plugin::AMD::EncoderH265::GetAspectRatio()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_ASPECT_RATIO, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return std::make_pair(e.num, e.den);
@@ -229,8 +229,8 @@ void Plugin::AMD::EncoderH265::SetFrameRate(std::pair<uint32_t, uint32_t> v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_FRAMERATE, ::AMFConstructRate(v.first, v.second));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %ld/%ld, error %ls (code %d)",
-							 m_UniqueId, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %ld/%ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v.first, v.second, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	m_FrameRate = std::make_pair(v.first, v.second);
@@ -262,8 +262,8 @@ std::vector<Profile> Plugin::AMD::EncoderH265::CapsProfile()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_PROFILE, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -280,8 +280,8 @@ void Plugin::AMD::EncoderH265::SetProfile(Profile v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PROFILE, Utility::ProfileToAMFH265(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::ProfileToString(v), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::ProfileToString(v), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -294,8 +294,8 @@ Plugin::AMD::Profile Plugin::AMD::EncoderH265::GetProfile()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_PROFILE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return Utility::ProfileFromAMFH265((AMF_VIDEO_ENCODER_HEVC_PROFILE_ENUM)e);
@@ -309,8 +309,8 @@ std::vector<ProfileLevel> Plugin::AMD::EncoderH265::CapsProfileLevel()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_PROFILE_LEVEL, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -350,8 +350,8 @@ void Plugin::AMD::EncoderH265::SetProfileLevel(ProfileLevel v, std::pair<uint32_
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PROFILE_LEVEL, ((int64_t)v) * 3);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %lld, error %ls (code %d)",
-							 m_UniqueId, (int64_t)v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %lld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, (int64_t)v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -364,8 +364,8 @@ Plugin::AMD::ProfileLevel Plugin::AMD::EncoderH265::GetProfileLevel()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_PROFILE_LEVEL, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (ProfileLevel)(e / 3);
@@ -379,8 +379,8 @@ std::vector<H265::Tier> Plugin::AMD::EncoderH265::CapsTier()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_TIER, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -397,8 +397,8 @@ void Plugin::AMD::EncoderH265::SetTier(H265::Tier v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_TIER, Utility::TierToAMFH265(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::TierToString(v), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::TierToString(v), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -411,8 +411,8 @@ Plugin::AMD::H265::Tier Plugin::AMD::EncoderH265::GetTier()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_TIER, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (H265::Tier)e;
@@ -426,8 +426,8 @@ std::pair<uint64_t, uint64_t> Plugin::AMD::EncoderH265::CapsMaximumReferenceFram
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_MAX_NUM_REFRAMES, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -440,8 +440,8 @@ void Plugin::AMD::EncoderH265::SetMaximumReferenceFrames(uint64_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_NUM_REFRAMES, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %lld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %lld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -454,10 +454,8 @@ uint64_t Plugin::AMD::EncoderH265::GetMaximumReferenceFrames()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_NUM_REFRAMES, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg,
-							 __FUNCTION_NAME__ "<Id: %lld> <" __FUNCTION_NAME__
-											   "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -470,9 +468,8 @@ std::vector<CodingType> Plugin::AMD::EncoderH265::CapsCodingType()
 	const amf::AMFPropertyInfo* var;
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_CABAC_ENABLE, &var);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -489,8 +486,8 @@ void Plugin::AMD::EncoderH265::SetCodingType(CodingType v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_CABAC_ENABLE, Utility::CodingTypeToAMFH265(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::CodingTypeToString(v), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::CodingTypeToString(v), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -518,8 +515,8 @@ std::pair<uint32_t, uint32_t> Plugin::AMD::EncoderH265::CapsMaximumLongTermRefer
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_MAX_LTR_FRAMES, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -532,8 +529,8 @@ void Plugin::AMD::EncoderH265::SetMaximumLongTermReferenceFrames(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_LTR_FRAMES, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -545,8 +542,8 @@ uint32_t Plugin::AMD::EncoderH265::GetMaximumLongTermReferenceFrames()
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_LTR_FRAMES, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint32_t)e;
@@ -561,8 +558,8 @@ std::vector<RateControlMethod> Plugin::AMD::EncoderH265::CapsRateControlMethod()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -581,8 +578,8 @@ void Plugin::AMD::EncoderH265::SetRateControlMethod(RateControlMethod v)
 	AMF_RESULT res =
 		m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD, Utility::RateControlMethodToAMFH265(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::RateControlMethodToString(v), m_AMF->GetTrace()->GetResultText(res),
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::RateControlMethodToString(v), m_AMF->GetTrace()->GetResultText(res),
 							 res);
 		throw std::exception(errMsg.c_str());
 	}
@@ -596,8 +593,8 @@ Plugin::AMD::RateControlMethod Plugin::AMD::EncoderH265::GetRateControlMethod()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return Utility::RateControlMethodFromAMFH265((AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_ENUM)e);
@@ -611,8 +608,8 @@ std::vector<PrePassMode> Plugin::AMD::EncoderH265::CapsPrePassMode()
 	AMF_RESULT res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_PREANALYSIS_ENABLE, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	if (var->type == amf::AMF_VARIANT_BOOL) {
@@ -634,8 +631,8 @@ void Plugin::AMD::EncoderH265::SetPrePassMode(PrePassMode v)
 	AMF_RESULT res =
 		m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_PREANALYSIS_ENABLE, v != PrePassMode::Disabled);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, (v != PrePassMode::Disabled) ? "Enabled" : "Disabled",
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, (v != PrePassMode::Disabled) ? "Enabled" : "Disabled",
 							 m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
@@ -666,8 +663,8 @@ void Plugin::AMD::EncoderH265::SetVarianceBasedAdaptiveQuantizationEnabled(bool 
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -680,8 +677,8 @@ bool Plugin::AMD::EncoderH265::IsVarianceBasedAdaptiveQuantizationEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -696,8 +693,8 @@ std::pair<uint64_t, uint64_t> Plugin::AMD::EncoderH265::CapsVBVBufferSize()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_VBV_BUFFER_SIZE, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -710,8 +707,8 @@ void Plugin::AMD::EncoderH265::SetVBVBufferSize(uint64_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_VBV_BUFFER_SIZE, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %lld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %lld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -724,8 +721,8 @@ uint64_t Plugin::AMD::EncoderH265::GetVBVBufferSize()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_VBV_BUFFER_SIZE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -738,8 +735,8 @@ void Plugin::AMD::EncoderH265::SetVBVBufferInitialFullness(double v)
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_INITIAL_VBV_BUFFER_FULLNESS, (int64_t)(v * 64));
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %lf (%d), error %ls (code %d)",
-							 m_UniqueId, v, (uint8_t)(v * 64), m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Failed to set to %lf (%d), error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, (uint8_t)(v * 64), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -752,8 +749,8 @@ float Plugin::AMD::EncoderH265::GetInitialVBVBufferFullness()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_INITIAL_VBV_BUFFER_FULLNESS, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (e / 64.0f);
@@ -768,8 +765,8 @@ std::vector<H265::GOPType> Plugin::AMD::EncoderH265::CapsGOPType()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(L"GOPType", &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -786,8 +783,8 @@ void Plugin::AMD::EncoderH265::SetGOPType(H265::GOPType v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(L"GOPType", Utility::GOPTypeToAMFH265(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set mode to %s, error %ls (code %d)",
-							 m_UniqueId, Utility::GOPTypeToString(v), m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set mode to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, Utility::GOPTypeToString(v), m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -799,8 +796,8 @@ Plugin::AMD::H265::GOPType Plugin::AMD::EncoderH265::GetGOPType()
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(L"GOPType", &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return Utility::GOPTypeFromAMFH265(e);
@@ -812,8 +809,8 @@ void Plugin::AMD::EncoderH265::SetGOPSize(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -825,8 +822,8 @@ uint32_t Plugin::AMD::EncoderH265::GetGOPSize()
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint32_t)e;
@@ -838,8 +835,8 @@ void Plugin::AMD::EncoderH265::SetGOPSizeMin(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(L"GOPSizeMin", (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -851,8 +848,8 @@ uint32_t Plugin::AMD::EncoderH265::GetGOPSizeMin()
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(L"GOPSizeMin", &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint32_t)e;
@@ -864,8 +861,8 @@ void Plugin::AMD::EncoderH265::SetGOPSizeMax(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(L"GOPSizeMax", (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -877,8 +874,8 @@ uint32_t Plugin::AMD::EncoderH265::GetGOPSizeMax()
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(L"GOPSizeMax", &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint32_t)e;
@@ -890,8 +887,8 @@ void Plugin::AMD::EncoderH265::SetGOPAlignmentEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(L"EnableGOPAlignment", v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -903,8 +900,8 @@ bool Plugin::AMD::EncoderH265::IsGOPAlignmentEnabled()
 	bool       e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(L"EnableGOPAlignment", &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -916,8 +913,8 @@ void Plugin::AMD::EncoderH265::SetIDRPeriod(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	m_PeriodIDR = v;
@@ -930,8 +927,8 @@ uint32_t Plugin::AMD::EncoderH265::GetIDRPeriod()
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	m_PeriodIDR = (uint32_t)e;
@@ -945,8 +942,8 @@ void Plugin::AMD::EncoderH265::SetHeaderInsertionMode(H265::HeaderInsertionMode 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_HEADER_INSERTION_MODE,
 											   static_cast<AMF_VIDEO_ENCODER_HEVC_HEADER_INSERTION_MODE_ENUM>(v));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -958,8 +955,8 @@ Plugin::AMD::H265::HeaderInsertionMode Plugin::AMD::EncoderH265::GetHeaderInsert
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_HEADER_INSERTION_MODE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return static_cast<H265::HeaderInsertionMode>(e);
@@ -971,8 +968,8 @@ void Plugin::AMD::EncoderH265::SetDeblockingFilterEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_DE_BLOCKING_FILTER_DISABLE, !v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -985,8 +982,8 @@ bool Plugin::AMD::EncoderH265::IsDeblockingFilterEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(L"HevcDeBlockingFilter", &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -999,8 +996,8 @@ void Plugin::AMD::EncoderH265::SetMotionEstimationQuarterPixelEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MOTION_QUARTERPIXEL, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set mode to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set mode to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1013,8 +1010,8 @@ bool Plugin::AMD::EncoderH265::IsMotionEstimationQuarterPixelEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_MOTION_QUARTERPIXEL, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1026,8 +1023,8 @@ void Plugin::AMD::EncoderH265::SetMotionEstimationHalfPixelEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MOTION_HALF_PIXEL, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set mode to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set mode to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1040,8 +1037,8 @@ bool Plugin::AMD::EncoderH265::IsMotionEstimationHalfPixelEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_MOTION_HALF_PIXEL, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1054,8 +1051,8 @@ void Plugin::AMD::EncoderH265::SetFrameSkippingEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_SKIP_FRAME_ENABLE, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1068,8 +1065,8 @@ bool Plugin::AMD::EncoderH265::IsFrameSkippingEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_SKIP_FRAME_ENABLE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1081,8 +1078,8 @@ void Plugin::AMD::EncoderH265::SetEnforceHRDEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENFORCE_HRD, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1095,8 +1092,8 @@ bool Plugin::AMD::EncoderH265::IsEnforceHRDEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_ENFORCE_HRD, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1108,8 +1105,8 @@ void Plugin::AMD::EncoderH265::SetFillerDataEnabled(bool v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_FILLER_DATA_ENABLE, v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %s, error %ls (code %d)",
-							 m_UniqueId, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %s, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v ? "Enabled" : "Disabled", m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1122,8 +1119,8 @@ bool Plugin::AMD::EncoderH265::IsFillerDataEnabled()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_FILLER_DATA_ENABLE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1137,8 +1134,8 @@ std::pair<uint8_t, uint8_t> Plugin::AMD::EncoderH265::CapsIFrameQPMinimum()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_MIN_QP_I, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1151,8 +1148,8 @@ void Plugin::AMD::EncoderH265::SetIFrameQPMinimum(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MIN_QP_I, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1165,8 +1162,8 @@ uint8_t Plugin::AMD::EncoderH265::GetIFrameQPMinimum()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_MIN_QP_I, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -1180,8 +1177,8 @@ std::pair<uint8_t, uint8_t> Plugin::AMD::EncoderH265::CapsIFrameQPMaximum()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_MAX_QP_I, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1194,8 +1191,8 @@ void Plugin::AMD::EncoderH265::SetIFrameQPMaximum(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_I, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1208,8 +1205,8 @@ uint8_t Plugin::AMD::EncoderH265::GetIFrameQPMaximum()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_I, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -1223,8 +1220,8 @@ std::pair<uint8_t, uint8_t> Plugin::AMD::EncoderH265::CapsPFrameQPMinimum()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_MIN_QP_P, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1237,8 +1234,8 @@ void Plugin::AMD::EncoderH265::SetPFrameQPMinimum(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MIN_QP_P, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1251,8 +1248,8 @@ uint8_t Plugin::AMD::EncoderH265::GetPFrameQPMinimum()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_MIN_QP_P, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -1266,8 +1263,8 @@ std::pair<uint8_t, uint8_t> Plugin::AMD::EncoderH265::CapsPFrameQPMaximum()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_MAX_QP_P, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1280,8 +1277,8 @@ void Plugin::AMD::EncoderH265::SetPFrameQPMaximum(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_P, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1294,8 +1291,8 @@ uint8_t Plugin::AMD::EncoderH265::GetPFrameQPMaximum()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_P, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -1309,8 +1306,8 @@ std::pair<uint64_t, uint64_t> Plugin::AMD::EncoderH265::CapsTargetBitrate()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1323,8 +1320,8 @@ void Plugin::AMD::EncoderH265::SetTargetBitrate(uint64_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %lld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %lld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1337,8 +1334,8 @@ uint64_t Plugin::AMD::EncoderH265::GetTargetBitrate()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1352,8 +1349,8 @@ std::pair<uint64_t, uint64_t> Plugin::AMD::EncoderH265::CapsPeakBitrate()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1366,8 +1363,8 @@ void Plugin::AMD::EncoderH265::SetPeakBitrate(uint64_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %lld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %lld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1380,8 +1377,8 @@ uint64_t Plugin::AMD::EncoderH265::GetPeakBitrate()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return e;
@@ -1395,8 +1392,8 @@ std::pair<uint8_t, uint8_t> Plugin::AMD::EncoderH265::CapsIFrameQP()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_QP_I, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1409,8 +1406,8 @@ void Plugin::AMD::EncoderH265::SetIFrameQP(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QP_I, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1423,8 +1420,8 @@ uint8_t Plugin::AMD::EncoderH265::GetIFrameQP()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_QP_I, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -1438,8 +1435,8 @@ std::pair<uint8_t, uint8_t> Plugin::AMD::EncoderH265::CapsPFrameQP()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(AMF_VIDEO_ENCODER_HEVC_QP_P, &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1452,8 +1449,8 @@ void Plugin::AMD::EncoderH265::SetPFrameQP(uint8_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QP_P, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %d, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %d, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1466,8 +1463,8 @@ uint8_t Plugin::AMD::EncoderH265::GetPFrameQP()
 
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_QP_P, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint8_t)e;
@@ -1479,8 +1476,8 @@ void Plugin::AMD::EncoderH265::SetMaximumAccessUnitSize(uint32_t v)
 
 	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_AU_SIZE, (int64_t)v);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to set to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1492,8 +1489,8 @@ uint32_t Plugin::AMD::EncoderH265::GetMaximumAccessUnitSize()
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_AU_SIZE, &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint32_t)e;
@@ -1507,8 +1504,8 @@ std::pair<uint32_t, uint32_t> Plugin::AMD::EncoderH265::CapsInputQueueSize()
 	AMF_RESULT                  res = m_AMFEncoder->GetPropertyInfo(L"HevcInputQueueSize", &var);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Querying capabilities failed, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Querying capabilities failed, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 
@@ -1522,8 +1519,8 @@ void Plugin::AMD::EncoderH265::SetInputQueueSize(uint32_t v)
 	AMF_RESULT res = m_AMFEncoder->SetProperty(L"HevcInputQueueSize", v);
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg,
-							 "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to set mode to %ld, error %ls (code %d)",
-							 m_UniqueId, v, m_AMF->GetTrace()->GetResultText(res), res);
+							 "<Id: %lld> <%s> Failed to set mode to %ld, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 }
@@ -1535,8 +1532,8 @@ uint32_t Plugin::AMD::EncoderH265::GetInputQueueSize()
 	int64_t    e;
 	AMF_RESULT res = m_AMFEncoder->GetProperty(L"HevcInputQueueSize", &e);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <" __FUNCTION_NAME__ "> Failed to retrieve value, error %ls (code %d)",
-							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %lld> <%s> Failed to retrieve value, error %ls (code %d)",
+							 m_UniqueId, __FUNCTION_NAME__, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
 	return (uint32_t)e;

--- a/source/amf-encoder.cpp
+++ b/source/amf-encoder.cpp
@@ -541,7 +541,7 @@ void Plugin::AMD::Encoder::GetVideoInfo(struct video_scale_info* info)
 	AMFTRACECALL;
 
 	if (!m_AMFContext || !m_AMFEncoder)
-		throw std::exception("<" __FUNCTION_NAME__ "> Called while not initialized.");
+		throw std::exception("Called while not initialized.");
 
 	switch (m_ColorFormat) {
 	// 4:2:0 Formats
@@ -580,7 +580,7 @@ bool Plugin::AMD::Encoder::GetExtraData(uint8_t** extra_data, size_t* size)
 	AMFTRACECALL;
 
 	if (!m_AMFContext || !m_AMFEncoder)
-		throw std::exception("<" __FUNCTION_NAME__ "> Called while not initialized.");
+		throw std::exception("Called while not initialized.");
 
 	amf::AMFVariant var;
 	AMF_RESULT      res = GetExtraDataInternal(&var);

--- a/source/amf.cpp
+++ b/source/amf.cpp
@@ -104,7 +104,7 @@ Plugin::AMD::AMF::AMF()
 #endif
 
 	// Initialize AMF Library
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Initializing...");
+	PLOG_DEBUG("<%s> Initializing...", __FUNCTION_NAME__);
 
 	// Load AMF Runtime Library
 	m_AMFModule = LoadLibraryW(AMF_DLL_NAME);
@@ -112,7 +112,7 @@ Plugin::AMD::AMF::AMF()
 		QUICK_FORMAT_MESSAGE(msg, "Unable to load '%ls', error code %ld.", AMF_DLL_NAME, GetLastError());
 		throw std::exception(msg.data());
 	} else {
-		PLOG_DEBUG("<" __FUNCTION_NAME__ "> Loaded '%ls'.", AMF_DLL_NAME);
+		PLOG_DEBUG("<%s> Loaded '%ls'.", __FUNCTION_NAME__, AMF_DLL_NAME);
 	}
 
 // Windows: Get Product Version for Driver Matching
@@ -173,7 +173,7 @@ Plugin::AMD::AMF::AMF()
 			throw std::exception(msg.data());
 		}
 	}
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> AMF Library initialized.");
+	PLOG_DEBUG("<%s> AMF Library initialized.", __FUNCTION_NAME__);
 
 	/// Retrieve Trace Object.
 	res = m_AMFFactory->GetTrace(&m_AMFTrace);
@@ -210,12 +210,12 @@ Plugin::AMD::AMF::AMF()
 		(uint16_t)((m_AMFVersion_Runtime >> 32ull) & 0xFFFF), (uint16_t)((m_AMFVersion_Runtime >> 16ull) & 0xFFFF),
 		(uint16_t)((m_AMFVersion_Runtime & 0xFFFF)), lProductVersionSize, pProductVersion);
 
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Initialized.");
+	PLOG_DEBUG("<%s> Initialized.", __FUNCTION_NAME__);
 }
 
 Plugin::AMD::AMF::~AMF()
 {
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Finalizing.");
+	PLOG_DEBUG("<%s> Finalizing.", __FUNCTION_NAME__);
 	if (m_AMFModule) {
 		if (m_TraceWriter) {
 			if (m_AMFTrace)
@@ -226,7 +226,7 @@ Plugin::AMD::AMF::~AMF()
 
 		FreeLibrary(m_AMFModule);
 	}
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Finalized.");
+	PLOG_DEBUG("<%s> Finalized.", __FUNCTION_NAME__);
 
 #pragma region Null Class Members
 	m_TimerPeriod        = 0;
@@ -260,9 +260,9 @@ amf::AMFDebug* Plugin::AMD::AMF::GetDebug()
 void Plugin::AMD::AMF::EnableDebugTrace(bool enable)
 {
 	if (!m_AMFTrace)
-		throw std::exception("<" __FUNCTION_NAME__ "> called without a AMFTrace object!");
+		throw std::exception("called without a AMFTrace object!");
 	if (!m_AMFDebug)
-		throw std::exception("<" __FUNCTION_NAME__ "> called without a AMFDebug object!");
+		throw std::exception("called without a AMFDebug object!");
 
 #ifndef _WIN64
 	// Older drivers crash due to using the wrong calling standard.

--- a/source/api-d3d11.cpp
+++ b/source/api-d3d11.cpp
@@ -134,8 +134,11 @@ Plugin::API::Direct3D11::Direct3D11()
 {
 	auto    dxgiInst = SingletonDXGI::GetInstance();
 	HRESULT hr       = dxgiInst->CreateDXGIFactory1(__uuidof(IDXGIFactory1), (void**)&m_DXGIFactory);
-	if (FAILED(hr))
-		throw std::exception("<" __FUNCTION_NAME__ "> Unable to create DXGI, error code %X.", hr);
+	if (FAILED(hr)) {
+		std::vector<char> buf(1024);
+		snprintf(buf.data(), buf.size(), "<%s> Unable to create DXGI, error code %X.", __FUNCTION_NAME__, hr);
+		throw std::exception(buf.data());
+	}
 
 	// Enumerate Adapters
 	IDXGIAdapter1* dxgiAdapter = nullptr;
@@ -236,15 +239,14 @@ Plugin::API::Direct3D11Instance::Direct3D11Instance(Direct3D11* api, Adapter ada
 			if (SUCCEEDED(hr)) {
 				break;
 			} else {
-				PLOG_DEBUG("<" __FUNCTION_NAME__
-						   "> Unable to create D3D11 device, error code %X (mode %lld, level %lld).",
-						   hr, enabledFlags, featureLevel);
+				PLOG_DEBUG("<%s> Unable to create D3D11 device, error code %X (mode %lld, level %lld).",
+						   __FUNCTION_NAME__, hr, enabledFlags, featureLevel);
 			}
 		}
 	}
 	if (FAILED(hr)) {
 		std::vector<char> buf(1024);
-		snprintf(buf.data(), buf.size(), "<" __FUNCTION_NAME__ "> Unable to create D3D11 device, error code %X.", hr);
+		snprintf(buf.data(), buf.size(), "<%s> Unable to create D3D11 device, error code %X.", __FUNCTION_NAME__, hr);
 		throw std::exception(buf.data());
 	}
 }

--- a/source/api-d3d9.cpp
+++ b/source/api-d3d9.cpp
@@ -27,8 +27,11 @@ using namespace Plugin::API;
 Plugin::API::Direct3D9::Direct3D9()
 {
 	HRESULT hr = Direct3DCreate9Ex(D3D_SDK_VERSION, &m_Direct3D9Ex);
-	if (FAILED(hr))
-		throw std::exception("<" __FUNCTION_NAME__ "> Failed to create D3D9Ex, error code %X.", hr);
+	if (FAILED(hr)) {
+		std::vector<char> buf(1024);
+		snprintf(buf.data(), buf.size(), "<%s> Failed to create D3D9Ex, error code %X.", __FUNCTION_NAME__, hr);
+		throw std::exception(buf.data());
+	}
 
 	std::list<LUID>        enumeratedLUIDs;
 	D3DADAPTER_IDENTIFIER9 adapterIdentifier;
@@ -136,7 +139,7 @@ Plugin::API::Direct3D9Instance::Direct3D9Instance(Direct3D9* api, Adapter adapte
 	if (FAILED(hr)) {
 		std::vector<char> buf(1024);
 		snprintf(buf.data(), buf.size(),
-				 "<" __FUNCTION_NAME__ "> Unable to query capabilities for D3D9 adapter, error code %X.", hr);
+				 "<%s> Unable to query capabilities for D3D9 adapter, error code %X.", __FUNCTION_NAME__, hr);
 		throw std::exception(buf.data());
 	}
 
@@ -152,7 +155,7 @@ Plugin::API::Direct3D9Instance::Direct3D9Instance(Direct3D9* api, Adapter adapte
 											&presentParameters, NULL, &m_Device);
 	if (FAILED(hr)) {
 		std::vector<char> buf(1024);
-		snprintf(buf.data(), buf.size(), "<" __FUNCTION_NAME__ "> Unable to create D3D9 device, error code %X.", hr);
+		snprintf(buf.data(), buf.size(), "<%s> Unable to create D3D9 device, error code %X.", __FUNCTION_NAME__, hr);
 		throw std::exception(buf.data());
 	}
 }
@@ -178,7 +181,7 @@ Plugin::API::Adapter Plugin::API::Direct3D9Instance::GetAdapter()
 	HRESULT hr = instance->device->GetCreationParameters(&par);
 	if (FAILED(hr)) {
 		std::vector<char> buf(1024);
-		snprintf(buf.data(), "<" __FUNCTION_NAME__ "> Unable to get adapter from D3D9 device, error code %X.", hr);
+		snprintf(buf.data(), "<%s> Unable to get adapter from D3D9 device, error code %X.", __FUNCTION_NAME__, hr);
 		throw std::exception(buf.data());
 	}
 

--- a/source/enc-h264.cpp
+++ b/source/enc-h264.cpp
@@ -1251,7 +1251,7 @@ bool Plugin::Interface::H264Interface::get_extra_data(void* data, uint8_t** extr
 //////////////////////////////////////////////////////////////////////////
 Plugin::Interface::H264Interface::H264Interface(obs_data_t* data, obs_encoder_t* encoder)
 {
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Initializing...");
+	PLOG_DEBUG("<%s> Initializing...", __FUNCTION_NAME__ );
 
 	m_Encoder = encoder;
 
@@ -1383,17 +1383,17 @@ Plugin::Interface::H264Interface::H264Interface(obs_data_t* data, obs_encoder_t*
 	// Dynamic Properties (Can be changed during Encoding)
 	this->update(data);
 
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Complete.");
+	PLOG_DEBUG("<%s> Complete.", __FUNCTION_NAME__);
 }
 
 Plugin::Interface::H264Interface::~H264Interface()
 {
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Finalizing...");
+	PLOG_DEBUG("<%s> Finalizing...", __FUNCTION_NAME__);
 	if (m_VideoEncoder) {
 		m_VideoEncoder->Stop();
 		m_VideoEncoder = nullptr;
 	}
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Complete.");
+	PLOG_DEBUG("<%s> Complete.", __FUNCTION_NAME__);
 }
 
 bool Plugin::Interface::H264Interface::update(obs_data_t* data)

--- a/source/enc-h265.cpp
+++ b/source/enc-h265.cpp
@@ -830,7 +830,7 @@ void* Plugin::Interface::H265Interface::create(obs_data_t* data, obs_encoder_t* 
 
 Plugin::Interface::H265Interface::H265Interface(obs_data_t* data, obs_encoder_t* encoder)
 {
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Initializing...");
+	PLOG_DEBUG("<%s> Initializing...", __FUNCTION_NAME__);
 
 	m_Encoder = encoder;
 
@@ -1023,7 +1023,7 @@ Plugin::Interface::H265Interface::H265Interface(obs_data_t* data, obs_encoder_t*
 	// Dynamic Properties (Can be changed during Encoding)
 	this->update(data);
 
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Complete.");
+	PLOG_DEBUG("<%s> Complete.", __FUNCTION_NAME__);
 }
 
 void Plugin::Interface::H265Interface::destroy(void* ptr)
@@ -1034,12 +1034,12 @@ void Plugin::Interface::H265Interface::destroy(void* ptr)
 
 Plugin::Interface::H265Interface::~H265Interface()
 {
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Finalizing...");
+	PLOG_DEBUG("<%s> Finalizing...", __FUNCTION_NAME__);
 	if (m_VideoEncoder) {
 		m_VideoEncoder->Stop();
 		m_VideoEncoder = nullptr;
 	}
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Complete.");
+	PLOG_DEBUG("<%s> Complete.", __FUNCTION_NAME__);
 }
 
 bool Plugin::Interface::H265Interface::update(void* ptr, obs_data_t* settings)

--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -187,7 +187,7 @@ static void printDebugInfo(amf::AMFComponentPtr m_AMFEncoder)
 
 MODULE_EXPORT bool obs_module_load(void)
 {
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Loading...");
+	PLOG_DEBUG("<%s> Loading...", __FUNCTION_NAME__);
 
 #ifdef _WIN32
 	// Out-of-process AMF Test
@@ -346,7 +346,7 @@ MODULE_EXPORT bool obs_module_load(void)
 	}
 #endif
 
-	PLOG_DEBUG("<" __FUNCTION_NAME__ "> Loaded.");
+	PLOG_DEBUG("<%s> Loaded.", __FUNCTION_NAME__);
 	return true;
 }
 


### PR DESCRIPTION
This change allows all __FUNCTION_NAME__ usages to work on clang-cl.
Previously it depended on __FUNCTION_NAME__ behaving as a string
literal instead of a const char *.