### PR TITLE
Fix typos

### DIFF
--- a/source/amf-encoder.cpp
+++ b/source/amf-encoder.cpp
@@ -199,7 +199,7 @@ Plugin::AMD::Encoder::Encoder(Codec codec, std::shared_ptr<API::IAPI> videoAPI, 
 	res =
 		m_AMFConverter->SetProperty(AMF_VIDEO_CONVERTER_COLOR_PROFILE, Utility::ColorSpaceToAMFConverter(m_ColorSpace));
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %llu> Unable to set convertor color profile, error %ls (code %d)",
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %llu> Unable to set converter color profile, error %ls (code %d)",
 							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
@@ -425,7 +425,7 @@ void Plugin::AMD::Encoder::Start()
 
 	res = m_AMFConverter->Init(Utility::ColorFormatToAMF(m_ColorFormat), m_Resolution.first, m_Resolution.second);
 	if (res != AMF_OK) {
-		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %llu> Unable to initalize converter, error %ls (code %d)", m_UniqueId,
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %llu> Unable to initialize converter, error %ls (code %d)", m_UniqueId,
 							 m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}

--- a/source/enc-h264.cpp
+++ b/source/enc-h264.cpp
@@ -355,13 +355,13 @@ obs_properties_t* Plugin::Interface::H264Interface::get_properties(void* data)
 	obs_property_list_add_int(p, P_TRANSLATE(P_UTIL_SWITCH_ENABLED), 1);
 #pragma endregion VBAQ
 
-#pragma region Enforce Hyptothetical Reference Decoder Restrictions
+#pragma region Enforce Hypothetical Reference Decoder Restrictions
 	p = obs_properties_add_list(props, P_ENFORCEHRD, P_TRANSLATE(P_ENFORCEHRD), OBS_COMBO_TYPE_LIST,
 								OBS_COMBO_FORMAT_INT);
 	obs_property_set_long_description(p, P_TRANSLATE(P_DESC(P_ENFORCEHRD)));
 	obs_property_list_add_int(p, P_TRANSLATE(P_UTIL_SWITCH_DISABLED), 0);
 	obs_property_list_add_int(p, P_TRANSLATE(P_UTIL_SWITCH_ENABLED), 1);
-#pragma endregion Enforce Hyptothetical Reference Decoder Restrictions
+#pragma endregion Enforce Hypothetical Reference Decoder Restrictions
 
 	{ // High Motion Quality Boost
 		p = obs_properties_add_list(props, P_HIGHMOTIONQUALITYBOOST, P_TRANSLATE(P_HIGHMOTIONQUALITYBOOST),
@@ -711,7 +711,7 @@ bool Plugin::Interface::H264Interface::properties_modified(obs_properties_t* pro
 				}
 			}
 		} catch (const std::exception& e) {
-			PLOG_ERROR("Exception occured while updating capabilities: %s", e.what());
+			PLOG_ERROR("Exception occurred while updating capabilities: %s", e.what());
 		}
 	}
 #pragma endregion Video API& Adapter

--- a/source/enc-h265.cpp
+++ b/source/enc-h265.cpp
@@ -320,7 +320,7 @@ obs_properties_t* Plugin::Interface::H265Interface::get_properties(void* data)
 	obs_property_set_long_description(p, P_TRANSLATE(P_DESC(P_ENFORCEHRD)));
 	obs_property_list_add_int(p, P_TRANSLATE(P_UTIL_SWITCH_DISABLED), 0);
 	obs_property_list_add_int(p, P_TRANSLATE(P_UTIL_SWITCH_ENABLED), 1);
-#pragma endregion Enforce Hyptothetical Reference Decoder Restrictions
+#pragma endregion Enforce Hypothetical Reference Decoder Restrictions
 
 	{ // High Motion Quality Boost
 		p = obs_properties_add_list(props, P_HIGHMOTIONQUALITYBOOST, P_TRANSLATE(P_HIGHMOTIONQUALITYBOOST),
@@ -591,7 +591,7 @@ bool Plugin::Interface::H265Interface::properties_modified(obs_properties_t* pro
 			TEMP_LIMIT_SLIDER_BITRATE(CapsPeakBitrate, P_BITRATE_PEAK);
 			TEMP_LIMIT_SLIDER_BITRATE(CapsVBVBufferSize, P_VBVBUFFER_SIZE);
 		} catch (const std::exception& e) {
-			PLOG_ERROR("Exception occured while updating capabilities: %s", e.what());
+			PLOG_ERROR("Exception occurred while updating capabilities: %s", e.what());
 		}
 	}
 #pragma endregion Video API& Adapter

--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -256,7 +256,7 @@ MODULE_EXPORT bool obs_module_load(void)
 		case STATUS_STACK_OVERFLOW:
 		case STATUS_UNWIND_CONSOLIDATE:
 		default:
-			PLOG_ERROR("A critical error occured during AMF Testing.");
+			PLOG_ERROR("A critical error occurred during AMF Testing.");
 			return false;
 		case 2:
 		case 1:


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ini -L aci,amd,dur,iff,mut,numer,uint`