### PR TITLE
plugin: Rename clamp to amf_clamp

### DIFF
--- a/include/plugin.hpp
+++ b/include/plugin.hpp
@@ -49,7 +49,7 @@ extern "C" {
 #define vstr(s) dstr(s)
 #define dstr(s) #s
 
-#define clamp(val, low, high) (val > high ? high : (val < low ? low : val))
+#define amf_clamp(val, low, high) (val > high ? high : (val < low ? low : val))
 #ifdef max
 #undef max
 #endif

--- a/source/amf-encoder-h264.cpp
+++ b/source/amf-encoder-h264.cpp
@@ -1132,7 +1132,7 @@ void Plugin::AMD::EncoderH264::SetIDRPeriod(uint32_t v)
 {
 	AMFTRACECALL;
 
-	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, (int64_t)clamp(v, 1, 1000000));
+	AMF_RESULT res = m_AMFEncoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, (int64_t)amf_clamp(v, 1, 1000000));
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg, PREFIX "<%s> Failed to set to %ld, error %ls (code %d)",
 							 m_UniqueId, __FUNCTION_NAME__, v, m_AMF->GetTrace()->GetResultText(res), res);

--- a/source/amf-encoder.cpp
+++ b/source/amf-encoder.cpp
@@ -335,11 +335,11 @@ void Plugin::AMD::Encoder::SetVBVBufferStrictness(double_t v)
 
 	Usage usage = GetUsage();
 	if (usage == Usage::UltraLowLatency) {
-		targetBitrate = clamp(GetTargetBitrate(), bitrateCaps.first, bitrateCaps.second);
+		targetBitrate = amf_clamp(GetTargetBitrate(), bitrateCaps.first, bitrateCaps.second);
 	} else {
 		switch (this->GetRateControlMethod()) {
 		case RateControlMethod::ConstantBitrate:
-			targetBitrate = clamp(GetTargetBitrate(), bitrateCaps.first, bitrateCaps.second);
+			targetBitrate = amf_clamp(GetTargetBitrate(), bitrateCaps.first, bitrateCaps.second);
 			break;
 		case RateControlMethod::LatencyConstrainedVariableBitrate:
 		case RateControlMethod::PeakConstrainedVariableBitrate:
@@ -350,15 +350,15 @@ void Plugin::AMD::Encoder::SetVBVBufferStrictness(double_t v)
 			break;
 		}
 	}
-	strictBitrate = clamp(
+	strictBitrate = amf_clamp(
 		static_cast<uint64_t>(round(targetBitrate * ((double_t)m_FrameRate.second / (double_t)m_FrameRate.first))),
 		bitrateCaps.first, targetBitrate);
 
 	// Three-Point Linear Lerp
 	// 0% = looseBitrate, 50% = targetBitrate, 100% = strictBitrate
-	v                 = clamp(v, 0.0, 1.0);
-	double_t aFadeVal = clamp(v * 2.0, 0.0, 1.0);       // 0 - 0.5
-	double_t bFadeVal = clamp(v * 2.0 - 1.0, 0.0, 0.0); // 0.5 - 1.0
+	v                 = amf_clamp(v, 0.0, 1.0);
+	double_t aFadeVal = amf_clamp(v * 2.0, 0.0, 1.0);       // 0 - 0.5
+	double_t bFadeVal = amf_clamp(v * 2.0 - 1.0, 0.0, 0.0); // 0.5 - 1.0
 
 	double_t aFade = (looseBitrate * (1.0 - aFadeVal)) + (targetBitrate * aFadeVal);
 	double_t bFade = (aFade * (1.0 - bFadeVal)) + (strictBitrate * bFadeVal);

--- a/source/amf-encoder.cpp
+++ b/source/amf-encoder.cpp
@@ -358,7 +358,7 @@ void Plugin::AMD::Encoder::SetVBVBufferStrictness(double_t v)
 	// 0% = looseBitrate, 50% = targetBitrate, 100% = strictBitrate
 	v                 = amf_clamp(v, 0.0, 1.0);
 	double_t aFadeVal = amf_clamp(v * 2.0, 0.0, 1.0);       // 0 - 0.5
-	double_t bFadeVal = amf_clamp(v * 2.0 - 1.0, 0.0, 0.0); // 0.5 - 1.0
+	double_t bFadeVal = amf_clamp(v * 2.0 - 1.0, 0.0, 1.0); // 0.5 - 1.0
 
 	double_t aFade = (looseBitrate * (1.0 - aFadeVal)) + (targetBitrate * aFadeVal);
 	double_t bFade = (aFade * (1.0 - bFadeVal)) + (strictBitrate * bFadeVal);

--- a/source/enc-h265.cpp
+++ b/source/enc-h265.cpp
@@ -952,7 +952,7 @@ Plugin::Interface::H265Interface::H265Interface(obs_data_t* data, obs_encoder_t*
 	}
 
 	// Picture Control
-	uint32_t      gopSize = static_cast<uint32_t>(clamp(floor(obsFPSnum / (double_t)obsFPSden), 1, 1000));
+	uint32_t      gopSize = static_cast<uint32_t>(amf_clamp(floor(obsFPSnum / (double_t)obsFPSden), 1, 1000));
 	H265::GOPType gopType = static_cast<H265::GOPType>(obs_data_get_int(data, P_GOP_TYPE));
 	m_VideoEncoder->SetGOPType(gopType);
 	if (static_cast<ViewMode>(obs_data_get_int(data, P_VIEW)) >= ViewMode::Expert) {
@@ -977,7 +977,7 @@ Plugin::Interface::H265Interface::H265Interface(obs_data_t* data, obs_encoder_t*
 			double_t keyinterv = obs_data_get_double(data, P_INTERVAL_KEYFRAME);
 			idrperiod          = static_cast<uint32_t>(ceil((keyinterv * framerate) / gopSize));
 		}
-		m_VideoEncoder->SetIDRPeriod(clamp(idrperiod, 1, 1000));
+		m_VideoEncoder->SetIDRPeriod(amf_clamp(idrperiod, 1, 1000));
 	}
 	m_VideoEncoder->SetDeblockingFilterEnabled(!!obs_data_get_int(data, P_DEBLOCKINGFILTER));
 	m_VideoEncoder->SetMotionEstimationHalfPixelEnabled(!!(obs_data_get_int(data, P_MOTIONESTIMATION) & 1));


### PR DESCRIPTION
### Description
This fixes C++17 compilation, which defines its own clamp.

### Motivation and Context
Intend to enable C++17 for all of OBS to make it easier to implement WinRT features, and this is the only plugin regression.

### How Has This Been Tested?
Breakpoint-inspected all affected lines, and clamp operations still appear to work. H264 and H265 videos seem to look correct.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
