### PR TITLE
plugin: Use AGS to verify driver version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,14 @@ Configure_File(
 	"${PROJECT_BINARY_DIR}/include/version.hpp"
 )
 
+# AGS
+If(WIN32)
+	find_package(AGS REQUIRED)
+	include_directories(${AGS_INCLUDE_DIRS})
+else()
+	unset(AGS_LIBRARIES)
+endif()
+
 # Windows Specific Resource Definition
 If(WIN32)
 	Set(PROJECT_PRODUCT_NAME "OBS Studio AMD Encoder")
@@ -297,6 +305,7 @@ Target_Include_Directories(${PROJECT_NAME}
 If(${PropertyPrefix}OBS_NATIVE)
 	Target_Link_Libraries(${PROJECT_NAME}
 		libobs
+		${AGS_LIBRARIES}
 	)
 ElseIf(${PropertyPrefix}OBS_REFERENCE)
 	Target_Include_Directories(${PROJECT_NAME}


### PR DESCRIPTION
### Description
Use AGS to verify driver version.

### Motivation and Context
Hopefully, this will prevent AMF from having the chance to crash.

### How Has This Been Tested?
Breakpoint inspection. Successful run against Vega.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.