### PR TITLE
amf: Require AMF Runtime to match plugin version

### DIFF
--- a/source/amf.cpp
+++ b/source/amf.cpp
@@ -156,8 +156,9 @@ Plugin::AMD::AMF::AMF()
 	}
 
 	/// Blacklist Drivers with older SDK.
-	if (m_AMFVersion_Runtime < AMF_MAKE_FULL_VERSION(1, 4, 6, 0)) {
-		PLOG_WARNING("The AMF Runtime is very old and unsupported, consider updating your drivers.");
+	if (m_AMFVersion_Runtime < AMF_FULL_VERSION) {
+		PLOG_ERROR("The detected AMF runtime is too old, please update your drivers.");
+		throw std::runtime_error("AMF Runtime is outdated.");
 	}
 
 	/// Initialize AMF


### PR DESCRIPTION
### Description
Verify AMF runtime in GPU driver matches the plugin version, and fail gracefully if it doesn't.

This is a copy of https://github.com/Xaymar/obs-amd-encoder/commit/7225ecd8df02fc7267f004429e40015cdb5d2a91, but using AMF_FULL_VERSION instead of a hard-coded value for easier maintenance.

### Motivation and Context
I'm trying to get AMF stable enough to update the submodule from obs-studio to get my C++17 change through: https://github.com/obsproject/obs-studio/pull/2081

### How Has This Been Tested?
Changes tested against obs-studio master. OBS successfully fails if driver is too old.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate. (Sort of. The commit message isn't capped at 72 characters, but I copied the original text.)