### PR TITLE
plugin, amf-test: Fix AMF error message redirection

### DIFF
--- a/amf-test/main.cpp
+++ b/amf-test/main.cpp
@@ -48,11 +48,13 @@ int main(int argc, char* argv[])
 		API::FinalizeAPIs();
 		AMF::Finalize();
 		return 0;
-	} catch (std::exception ex) {
-		std::cout << ex.what() << std::endl;
+	} catch (std::exception& ex) {
+		printf("[AMF] %s", ex.what());
+		fflush(NULL);
 		return 1;
 	} catch (...) {
-		std::cout << "Unknown Error" << std::endl;
+		printf("[AMF] Unknown Error");
+		fflush(NULL);
 		return 2;
 	}
 }

--- a/include/plugin.hpp
+++ b/include/plugin.hpp
@@ -36,11 +36,12 @@ extern "C" {
 #define PLUGIN_NAME "AMD Advanced Media Framework"
 
 #ifndef LITE_OBS
-#define PLOG(level, ...) blog(level, "[AMF] " __VA_ARGS__);
+#define PLOG(level, ...) blog(level, "[AMF] " __VA_ARGS__)
+#define PLOG_ERROR(format, ...) PLOG(LOG_ERROR, format, __VA_ARGS__)
 #else
-#define PLOG(level, ...) ;
+#define PLOG(...) (void)0
+#define PLOG_ERROR(format, ...) printf("[AMF] " format "\n", __VA_ARGS__)
 #endif
-#define PLOG_ERROR(...) PLOG(LOG_ERROR, __VA_ARGS__)
 #define PLOG_WARNING(...) PLOG(LOG_WARNING, __VA_ARGS__)
 #define PLOG_INFO(...) PLOG(LOG_INFO, __VA_ARGS__)
 #define PLOG_DEBUG(...) PLOG(LOG_DEBUG, __VA_ARGS__)


### PR DESCRIPTION
### Description
Out-of-process test error messages work now, and with the correct number of line breaks and [AMF] prefixes.

### Motivation and Context
Error messages were not working at all when I tested on my machine. Now they do, so this will make it easier to diagnose user failures.

### How Has This Been Tested?
Runs on my machine.

    'obs64.exe' (Win32): Loaded 'C:\Users\James\source\repos\branches\master\obs-studio\build64\rundir\Debug\obs-plugins\64bit\enc-amf.dll'. Symbols loaded.
    Loading module: enc-amf.dll
    [AMF] <obs_module_load> Loading...
    [AMF] The detected AMF runtime is too old, please update your drivers.
    [AMF] AMF Runtime is outdated.
    [AMF] AMF Test failed due to one or more errors.
    Failed to initialize module 'enc-amf.dll'

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.