### PR TITLE
API: Fix vector indexing

### DIFF
--- a/source/api-base.cpp
+++ b/source/api-base.cpp
@@ -146,24 +146,18 @@ size_t Plugin::API::CountAPIs()
 
 std::string Plugin::API::GetAPIName(size_t index)
 {
-	auto indAPI = s_APIInstances.begin();
-	indAPI + index; // Advanced by x elements.
-
-	if (indAPI == s_APIInstances.end())
+	if (index >= s_APIInstances.size())
 		throw std::exception("Invalid API Index");
 
-	return indAPI->get()->GetName();
+	return s_APIInstances[index].get()->GetName();
 }
 
 std::shared_ptr<IAPI> Plugin::API::GetAPI(size_t index)
 {
-	auto indAPI = s_APIInstances.begin();
-	indAPI + index; // Advanced by x elements.
-
-	if (indAPI == s_APIInstances.end())
+	if (index >= s_APIInstances.size())
 		throw std::exception("Invalid API Index");
 
-	return *indAPI;
+	return s_APIInstances[index];
 }
 
 std::shared_ptr<IAPI> Plugin::API::GetAPI(const std::string& name)


### PR DESCRIPTION
### Description
Functions were always looking at index 0. Bounds check was also not
checking for values greater than size. We weren't seeing issues because
these functions don't have active callers.

Fixes compiler warnings on Windows build.

### Motivation and Context
Looking through compiler warnings, and noticed these functions weren't implemented correctly.

### How Has This Been Tested?
No breakpoint inspection since these functions aren't called.

Windows 7 - Stop recording hangs with and without change.
Windows 10 - Recording works with and without change.

Windows compiler warnings are gone.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.