### PR TITLE
project: Fix VC++ warnings

### DIFF
--- a/include/plugin.hpp
+++ b/include/plugin.hpp
@@ -38,9 +38,11 @@ extern "C" {
 #ifndef LITE_OBS
 #define PLOG(level, ...) blog(level, "[AMF] " __VA_ARGS__)
 #define PLOG_ERROR(format, ...) PLOG(LOG_ERROR, format, __VA_ARGS__)
+#define PLOG_VAR(var) var
 #else
 #define PLOG(...) (void)0
 #define PLOG_ERROR(format, ...) printf("[AMF] " format "\n", __VA_ARGS__)
+#define PLOG_VAR(var)
 #endif
 #define PLOG_WARNING(...) PLOG(LOG_WARNING, __VA_ARGS__)
 #define PLOG_INFO(...) PLOG(LOG_INFO, __VA_ARGS__)

--- a/source/amf-encoder.cpp
+++ b/source/amf-encoder.cpp
@@ -907,7 +907,7 @@ bool Plugin::AMD::Encoder::EncodeLoad(IN amf::AMFDataPtr& data, OUT struct encod
 	PacketPriorityAndKeyframe(data, packet);
 	packet->size = pBuffer->GetSize();
 	if (m_PacketDataBuffer.size() < packet->size) {
-		size_t newBufferSize = (size_t)exp2(ceil(log2(packet->size)));
+		size_t newBufferSize = (size_t)exp2(ceil(log2((double)packet->size)));
 		//AMF_LOG_DEBUG("Packet Buffer was resized to %d byte from %d byte.", newBufferSize, m_PacketDataBuffer.size());
 		m_PacketDataBuffer.resize(newBufferSize);
 	}

--- a/source/api-base.cpp
+++ b/source/api-base.cpp
@@ -105,7 +105,7 @@ void                                      Plugin::API::InitializeAPIs()
 		// DirectX 11
 		try {
 			s_APIInstances.insert(s_APIInstances.end(), std::make_shared<Direct3D11>());
-		} catch (const std::exception& ex) {
+		} catch (const std::exception& PLOG_VAR(ex)) {
 			PLOG_WARNING("Direct3D 11 is not supported due to error: %s", ex.what());
 		} catch (...) {
 			PLOG_WARNING("Direct3D 11 not supported.");
@@ -114,7 +114,7 @@ void                                      Plugin::API::InitializeAPIs()
 		// Direct3D 9
 		try {
 			s_APIInstances.insert(s_APIInstances.end(), std::make_shared<Direct3D9>());
-		} catch (const std::exception& ex) {
+		} catch (const std::exception& PLOG_VAR(ex)) {
 			PLOG_WARNING("Direct3D 9 is not supported due to error: %s", ex.what());
 		} catch (...) {
 			PLOG_WARNING("Direct3D 9 not supported.");


### PR DESCRIPTION
### Description
Add support for unreferenced variables when logging is disabled, and
cast size_t for function that wants double.

### Motivation and Context
Reduce build warning spam.

### How Has This Been Tested?
Compiler warnings are gone.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.