### PR TITLE
project: Add ColorSpace SRGB enum value

### DIFF
--- a/include/amf-encoder.hpp
+++ b/include/amf-encoder.hpp
@@ -102,6 +102,7 @@ namespace Plugin {
 			BT601,
 			BT709,
 			BT2020,
+			SRGB,
 		};
 
 		// Properties

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -53,6 +53,7 @@ namespace Utility {
 	// Color Space
 	const char*                            ColorSpaceToString(Plugin::AMD::ColorSpace v);
 	AMF_VIDEO_CONVERTER_COLOR_PROFILE_ENUM ColorSpaceToAMFConverter(Plugin::AMD::ColorSpace v);
+	AMF_COLOR_TRANSFER_CHARACTERISTIC_ENUM ColorSpaceToTransferCharacteristic(Plugin::AMD::ColorSpace v);
 
 	// Usage
 	const char*                       UsageToString(Plugin::AMD::Usage v);

--- a/source/amf-encoder.cpp
+++ b/source/amf-encoder.cpp
@@ -203,6 +203,13 @@ Plugin::AMD::Encoder::Encoder(Codec codec, std::shared_ptr<API::IAPI> videoAPI, 
 							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
 		throw std::exception(errMsg.c_str());
 	}
+	res = m_AMFConverter->SetProperty(AMF_VIDEO_CONVERTER_TRANSFER_CHARACTERISTIC,
+									  Utility::ColorSpaceToTransferCharacteristic(m_ColorSpace));
+	if (res != AMF_OK) {
+		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %llu> Unable to set converter transfer characteristic, error %ls (code %d)",
+							 m_UniqueId, m_AMF->GetTrace()->GetResultText(res), res);
+		PLOG_WARNING("%s", errMsg.c_str());
+	}
 
 	// Create Encoder
 	res = m_AMFFactory->CreateComponent(m_AMFContext, Utility::CodecToAMF(codec), &m_AMFEncoder);

--- a/source/enc-h264.cpp
+++ b/source/enc-h264.cpp
@@ -63,7 +63,8 @@ const char* Plugin::Interface::H264Interface::get_name(void*) noexcept
 	return "H264/AVC Encoder (" PLUGIN_NAME ")";
 }
 
-void* Plugin::Interface::H264Interface::create(obs_data_t* settings, obs_encoder_t* encoder) noexcept try {
+void* Plugin::Interface::H264Interface::create(obs_data_t* settings, obs_encoder_t* encoder) noexcept
+try {
 	try {
 		return new Plugin::Interface::H264Interface(settings, encoder);
 	} catch (const std::exception& e) {
@@ -75,7 +76,8 @@ void* Plugin::Interface::H264Interface::create(obs_data_t* settings, obs_encoder
 	return nullptr;
 }
 
-void Plugin::Interface::H264Interface::destroy(void* data) noexcept try {
+void Plugin::Interface::H264Interface::destroy(void* data) noexcept
+try {
 	if (data)
 		delete static_cast<Plugin::Interface::H264Interface*>(data);
 } catch (const std::exception& ex) {
@@ -85,7 +87,8 @@ void Plugin::Interface::H264Interface::destroy(void* data) noexcept try {
 }
 
 bool Plugin::Interface::H264Interface::encode(void* data, struct encoder_frame* frame, struct encoder_packet* packet,
-											  bool* received_packet) noexcept try {
+											  bool* received_packet) noexcept
+try {
 	if (data)
 		return static_cast<Plugin::Interface::H264Interface*>(data)->encode(frame, packet, received_packet);
 	return false;
@@ -177,7 +180,8 @@ void Plugin::Interface::H264Interface::get_defaults(obs_data_t* data) noexcept
 	obs_data_set_default_int(data, P_VERSION, PLUGIN_VERSION_FULL);
 }
 
-obs_properties_t* Plugin::Interface::H264Interface::get_properties(void* data) noexcept try {
+obs_properties_t* Plugin::Interface::H264Interface::get_properties(void* data) noexcept
+try {
 	obs_properties* props = obs_properties_create();
 	obs_property_t* p;
 
@@ -581,7 +585,8 @@ static void obs_data_transfer_settings(obs_data_t* data)
 }
 
 bool Plugin::Interface::H264Interface::properties_modified(obs_properties_t* props, obs_property_t*,
-														   obs_data_t*       data) noexcept try {
+														   obs_data_t*       data) noexcept
+try {
 	bool            result = false;
 	obs_property_t* p;
 
@@ -1220,7 +1225,8 @@ bool Plugin::Interface::H264Interface::properties_modified(obs_properties_t* pro
 	return false;
 }
 
-bool Plugin::Interface::H264Interface::update(void* data, obs_data_t* settings) noexcept try {
+bool Plugin::Interface::H264Interface::update(void* data, obs_data_t* settings) noexcept
+try {
 	if (data)
 		return static_cast<Plugin::Interface::H264Interface*>(data)->update(settings);
 	return false;
@@ -1232,7 +1238,8 @@ bool Plugin::Interface::H264Interface::update(void* data, obs_data_t* settings) 
 	return false;
 }
 
-void Plugin::Interface::H264Interface::get_video_info(void* data, struct video_scale_info* info) noexcept try {
+void Plugin::Interface::H264Interface::get_video_info(void* data, struct video_scale_info* info) noexcept
+try {
 	if (data)
 		return static_cast<Plugin::Interface::H264Interface*>(data)->get_video_info(info);
 } catch (const std::exception& ex) {
@@ -1241,7 +1248,8 @@ void Plugin::Interface::H264Interface::get_video_info(void* data, struct video_s
 	PLOG_ERROR("Unexpected unknown exception in %s.", __FUNCTION_NAME__);
 }
 
-bool Plugin::Interface::H264Interface::get_extra_data(void* data, uint8_t** extra_data, size_t* size) noexcept try {
+bool Plugin::Interface::H264Interface::get_extra_data(void* data, uint8_t** extra_data, size_t* size) noexcept
+try {
 	if (data)
 		return static_cast<Plugin::Interface::H264Interface*>(data)->get_extra_data(extra_data, size);
 	return false;
@@ -1304,6 +1312,9 @@ Plugin::Interface::H264Interface::H264Interface(obs_data_t* data, obs_encoder_t*
 		break;
 	case VIDEO_CS_709:
 		colorSpace = ColorSpace::BT709;
+		break;
+	case VIDEO_CS_SRGB:
+		colorSpace = ColorSpace::SRGB;
 		break;
 	}
 

--- a/source/enc-h265.cpp
+++ b/source/enc-h265.cpp
@@ -142,7 +142,8 @@ void Plugin::Interface::H265Interface::get_defaults(obs_data_t* data) noexcept
 	obs_data_set_default_int(data, P_VERSION, PLUGIN_VERSION_FULL);
 }
 
-obs_properties_t* Plugin::Interface::H265Interface::get_properties(void* data) noexcept try {
+obs_properties_t* Plugin::Interface::H265Interface::get_properties(void* data) noexcept
+try {
 	obs_properties* props = obs_properties_create();
 	obs_property_t* p;
 
@@ -466,7 +467,8 @@ static void obs_data_transfer_settings(obs_data_t* data)
 }
 
 bool Plugin::Interface::H265Interface::properties_modified(obs_properties_t* props, obs_property_t*,
-														   obs_data_t*       data) noexcept try {
+														   obs_data_t*       data) noexcept
+try {
 	bool            result = false;
 	obs_property_t* p;
 
@@ -865,6 +867,9 @@ Plugin::Interface::H265Interface::H265Interface(obs_data_t* data, obs_encoder_t*
 	case VIDEO_CS_709:
 		colorSpace = ColorSpace::BT709;
 		break;
+	case VIDEO_CS_SRGB:
+		colorSpace = ColorSpace::SRGB;
+		break;
 	}
 
 	auto api = API::GetAPI(obs_data_get_string(data, P_VIDEO_API));
@@ -1021,7 +1026,8 @@ Plugin::Interface::H265Interface::H265Interface(obs_data_t* data, obs_encoder_t*
 	PLOG_DEBUG("<%s> Complete.", __FUNCTION_NAME__);
 }
 
-void Plugin::Interface::H265Interface::destroy(void* ptr) noexcept try {
+void Plugin::Interface::H265Interface::destroy(void* ptr) noexcept
+try {
 	if (ptr)
 		delete static_cast<H265Interface*>(ptr);
 } catch (const std::exception& ex) {
@@ -1040,7 +1046,8 @@ Plugin::Interface::H265Interface::~H265Interface()
 	PLOG_DEBUG("<%s> Complete.", __FUNCTION_NAME__);
 }
 
-bool Plugin::Interface::H265Interface::update(void* ptr, obs_data_t* settings) noexcept try {
+bool Plugin::Interface::H265Interface::update(void* ptr, obs_data_t* settings) noexcept
+try {
 	if (ptr)
 		return static_cast<H265Interface*>(ptr)->update(settings);
 	return false;
@@ -1124,7 +1131,8 @@ bool Plugin::Interface::H265Interface::update(obs_data_t* data)
 }
 
 bool Plugin::Interface::H265Interface::encode(void* ptr, struct encoder_frame* frame, struct encoder_packet* packet,
-											  bool* received_packet) noexcept try {
+											  bool* received_packet) noexcept
+try {
 	if (ptr)
 		return static_cast<H265Interface*>(ptr)->encode(frame, packet, received_packet);
 	return false;
@@ -1152,7 +1160,8 @@ bool Plugin::Interface::H265Interface::encode(struct encoder_frame* frame, struc
 	return false;
 }
 
-void Plugin::Interface::H265Interface::get_video_info(void* ptr, struct video_scale_info* info) noexcept try {
+void Plugin::Interface::H265Interface::get_video_info(void* ptr, struct video_scale_info* info) noexcept
+try {
 	if (ptr)
 		static_cast<H265Interface*>(ptr)->get_video_info(info);
 } catch (const std::exception& ex) {
@@ -1166,7 +1175,8 @@ void Plugin::Interface::H265Interface::get_video_info(struct video_scale_info* i
 	m_VideoEncoder->GetVideoInfo(info);
 }
 
-bool Plugin::Interface::H265Interface::get_extra_data(void* ptr, uint8_t** extra_data, size_t* size) noexcept try {
+bool Plugin::Interface::H265Interface::get_extra_data(void* ptr, uint8_t** extra_data, size_t* size) noexcept
+try {
 	if (ptr)
 		return static_cast<H265Interface*>(ptr)->get_extra_data(extra_data, size);
 	return false;

--- a/source/utility.cpp
+++ b/source/utility.cpp
@@ -204,6 +204,8 @@ const char* Utility::ColorSpaceToString(Plugin::AMD::ColorSpace v)
 		return "709";
 	case ColorSpace::BT2020:
 		return "2020";
+	case ColorSpace::SRGB:
+		return "sRGB";
 	}
 	throw std::runtime_error("Invalid Parameter");
 }
@@ -215,9 +217,25 @@ Utility::ColorSpaceToAMFConverter(Plugin::AMD::ColorSpace v)
 	case ColorSpace::BT601:
 		return AMF_VIDEO_CONVERTER_COLOR_PROFILE_601;
 	case ColorSpace::BT709:
+	case ColorSpace::SRGB:
 		return AMF_VIDEO_CONVERTER_COLOR_PROFILE_709;
 	case ColorSpace::BT2020:
 		return AMF_VIDEO_CONVERTER_COLOR_PROFILE_2020;
+	}
+	throw std::runtime_error("Invalid Parameter");
+}
+
+AMF_COLOR_TRANSFER_CHARACTERISTIC_ENUM Utility::ColorSpaceToTransferCharacteristic(Plugin::AMD::ColorSpace v)
+{
+	switch (v) {
+	case ColorSpace::BT601:
+		return AMF_COLOR_TRANSFER_CHARACTERISTIC_SMPTE170M;
+	case ColorSpace::BT709:
+		return AMF_COLOR_TRANSFER_CHARACTERISTIC_BT709;
+	case ColorSpace::BT2020:
+		return AMF_COLOR_TRANSFER_CHARACTERISTIC_BT2020_10;
+	case ColorSpace::SRGB:
+		return AMF_COLOR_TRANSFER_CHARACTERISTIC_IEC61966_2_1;
 	}
 	throw std::runtime_error("Invalid Parameter");
 }


### PR DESCRIPTION
### Description
Update color space handling for consistency with new sRGB value even though this doesn't seem to have much effect. VIDEO_CS_SRGB is only defined by OBS, and not yet used although this may change sooner than later.

### Motivation and Context
Adding sYCC support to OBS, and this plugin needs to handle the new enum value.

### How Has This Been Tested?
601 and 709 videos recorded with AMF still work.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.