### PR TITLE
amf: Fix destructor warning

### DIFF
--- a/source/amf.cpp
+++ b/source/amf.cpp
@@ -217,7 +217,7 @@ Plugin::AMD::AMF::~AMF()
 		if (m_TraceWriter) {
 			if (m_AMFTrace)
 				m_AMFTrace->UnregisterWriter(loggername);
-			delete m_TraceWriter;
+			delete static_cast<CustomWriter*>(m_TraceWriter);
 			m_TraceWriter = nullptr;
 		}
 


### PR DESCRIPTION
### Description
Base class has no virtual destructor. Delete derived class instead.

### Motivation and Context
I hate warnings.

### How Has This Been Tested?
Debugger inspection.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.