### PR TITLE
H264, H265: Update VIDEO_CS_DEFAULT to 709

### DIFF
--- a/source/enc-h264.cpp
+++ b/source/enc-h264.cpp
@@ -1306,10 +1306,10 @@ Plugin::Interface::H264Interface::H264Interface(obs_data_t* data, obs_encoder_t*
 	}
 	ColorSpace colorSpace = ColorSpace::BT601;
 	switch (voi->colorspace) {
-	case VIDEO_CS_DEFAULT:
 	case VIDEO_CS_601:
 		colorSpace = ColorSpace::BT601;
 		break;
+	case VIDEO_CS_DEFAULT:
 	case VIDEO_CS_709:
 		colorSpace = ColorSpace::BT709;
 		break;

--- a/source/enc-h265.cpp
+++ b/source/enc-h265.cpp
@@ -860,10 +860,10 @@ Plugin::Interface::H265Interface::H265Interface(obs_data_t* data, obs_encoder_t*
 	}
 	ColorSpace colorSpace = ColorSpace::BT601;
 	switch (voi->colorspace) {
-	case VIDEO_CS_DEFAULT:
 	case VIDEO_CS_601:
 		colorSpace = ColorSpace::BT601;
 		break;
+	case VIDEO_CS_DEFAULT:
 	case VIDEO_CS_709:
 		colorSpace = ColorSpace::BT709;
 		break;


### PR DESCRIPTION
### Description
H264, H265: Update VIDEO_CS_DEFAULT to 709

See main application PR: https://github.com/obsproject/obs-studio/pull/3415

### Motivation and Context
Color space consistency.

### How Has This Been Tested?
Debugger inspection of all changes. It doesn't seem like we ever pass VIDEO_CS_DEFAULT because the UI setting only has sRGB, 709 and 601.

### Types of changes
- Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
