### PR TITLE
Fix inability to set bitrate in latest AMD driver

### DIFF
--- a/source/amf-encoder-h264.cpp
+++ b/source/amf-encoder-h264.cpp
@@ -67,7 +67,12 @@ std::vector<Usage> Plugin::AMD::EncoderH264::CapsUsage()
 
 	std::vector<Usage> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::UsageFromAMFH264((AMF_VIDEO_ENCODER_USAGE_ENUM)enm->value));
+		try {
+			ret.push_back(Utility::UsageFromAMFH264((AMF_VIDEO_ENCODER_USAGE_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
+
 	}
 	return ret;
 }
@@ -108,7 +113,11 @@ std::vector<QualityPreset> Plugin::AMD::EncoderH264::CapsQualityPreset()
 
 	std::vector<QualityPreset> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::QualityPresetFromAMFH264((AMF_VIDEO_ENCODER_QUALITY_PRESET_ENUM)enm->value));
+		try {
+			ret.push_back(Utility::QualityPresetFromAMFH264((AMF_VIDEO_ENCODER_QUALITY_PRESET_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -150,7 +159,11 @@ std::vector<Profile> Plugin::AMD::EncoderH264::CapsProfile()
 
 	std::vector<Profile> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::ProfileFromAMFH264((AMF_VIDEO_ENCODER_PROFILE_ENUM)enm->value));
+		try {
+			ret.push_back(Utility::ProfileFromAMFH264((AMF_VIDEO_ENCODER_PROFILE_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -191,7 +204,11 @@ std::vector<ProfileLevel> Plugin::AMD::EncoderH264::CapsProfileLevel()
 
 	std::vector<ProfileLevel> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back((ProfileLevel)enm->value);
+		try {
+			ret.push_back((ProfileLevel)enm->value);
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -380,7 +397,11 @@ std::vector<CodingType> Plugin::AMD::EncoderH264::CapsCodingType()
 
 	std::vector<CodingType> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::CodingTypeFromAMFH264((AMF_VIDEO_ENCODER_CODING_ENUM)enm->value));
+		try {
+			ret.push_back(Utility::CodingTypeFromAMFH264((AMF_VIDEO_ENCODER_CODING_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -479,7 +500,11 @@ std::vector<RateControlMethod> Plugin::AMD::EncoderH264::CapsRateControlMethod()
 
 	std::vector<RateControlMethod> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::RateControlMethodFromAMFH264((AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_ENUM)enm->value));
+		try {
+			ret.push_back(Utility::RateControlMethodFromAMFH264((AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -521,7 +546,11 @@ std::vector<PrePassMode> Plugin::AMD::EncoderH264::CapsPrePassMode()
 
 	std::vector<PrePassMode> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::PrePassModeFromAMFH264((AMF_VIDEO_ENCODER_PREENCODE_MODE_ENUM)enm->value));
+		try {
+			ret.push_back(Utility::PrePassModeFromAMFH264((AMF_VIDEO_ENCODER_PREENCODE_MODE_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }

--- a/source/amf-encoder-h265.cpp
+++ b/source/amf-encoder-h265.cpp
@@ -58,7 +58,11 @@ std::vector<Usage> Plugin::AMD::EncoderH265::CapsUsage()
 
 	std::vector<Usage> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::UsageFromAMFH265((AMF_VIDEO_ENCODER_HEVC_USAGE_ENUM)enm->value));
+		try {
+			ret.push_back(Utility::UsageFromAMFH265((AMF_VIDEO_ENCODER_HEVC_USAGE_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -99,7 +103,11 @@ std::vector<QualityPreset> Plugin::AMD::EncoderH265::CapsQualityPreset()
 
 	std::vector<QualityPreset> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::QualityPresetFromAMFH265((AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_ENUM)enm->value));
+		try {
+			ret.push_back(Utility::QualityPresetFromAMFH265((AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -234,7 +242,11 @@ std::vector<Profile> Plugin::AMD::EncoderH265::CapsProfile()
 
 	std::vector<Profile> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::ProfileFromAMFH265((AMF_VIDEO_ENCODER_HEVC_PROFILE_ENUM)enm->value));
+		try {
+			ret.push_back(Utility::ProfileFromAMFH265((AMF_VIDEO_ENCODER_HEVC_PROFILE_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -275,7 +287,11 @@ std::vector<ProfileLevel> Plugin::AMD::EncoderH265::CapsProfileLevel()
 
 	std::vector<ProfileLevel> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back((ProfileLevel)(enm->value / 3));
+		try {
+			ret.push_back((ProfileLevel)(enm->value / 3));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -337,7 +353,11 @@ std::vector<H265::Tier> Plugin::AMD::EncoderH265::CapsTier()
 
 	std::vector<H265::Tier> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::TierFromAMFH265((AMF_VIDEO_ENCODER_HEVC_TIER_ENUM)enm->value));
+		try {
+			ret.push_back(Utility::TierFromAMFH265((AMF_VIDEO_ENCODER_HEVC_TIER_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -413,7 +433,11 @@ std::vector<CodingType> Plugin::AMD::EncoderH265::CapsCodingType()
 
 	std::vector<CodingType> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::CodingTypeFromAMFH265((AMF_VIDEO_ENCODER_CODING_ENUM)enm->value));
+		try {
+			ret.push_back(Utility::CodingTypeFromAMFH265((AMF_VIDEO_ENCODER_CODING_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -490,8 +514,12 @@ std::vector<RateControlMethod> Plugin::AMD::EncoderH265::CapsRateControlMethod()
 
 	std::vector<RateControlMethod> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(
+		try {
+			ret.push_back(
 			Utility::RateControlMethodFromAMFH265((AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_ENUM)enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }
@@ -690,7 +718,11 @@ std::vector<H265::GOPType> Plugin::AMD::EncoderH265::CapsGOPType()
 
 	std::vector<H265::GOPType> ret;
 	for (const amf::AMFEnumDescriptionEntry* enm = var->pEnumDescription; enm->name != nullptr; enm++) {
-		ret.push_back(Utility::GOPTypeFromAMFH265(enm->value));
+		try {
+			ret.push_back(Utility::GOPTypeFromAMFH265(enm->value));
+		} catch (...) {
+			// ignore unknown enum entries
+		}
 	}
 	return ret;
 }


### PR DESCRIPTION
Fixed issue: in enc_AMF plug-in bit rate cannot be set with the latet AMD driver.  Cause: AMF rate control mode enum now has a new value. When this value received from GetPropertyInfo() the enum translation function throws exception terminating plug-in initialization. Fix: unknown values in enums should be ignored. Applied for all enum translations.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
