### PR TITLE
enc-amf: Fix m3u8 recording

### DIFF
--- a/source/enc-h264.cpp
+++ b/source/enc-h264.cpp
@@ -1489,6 +1489,7 @@ bool Plugin::Interface::H264Interface::update(obs_data_t* data)
 			idrperiod          = static_cast<uint32_t>(ceil((keyinterv * framerate)));
 		}
 		m_VideoEncoder->SetIDRPeriod(idrperiod);
+		m_VideoEncoder->SetHeaderInsertionSpacing(idrperiod);
 	}
 	/// I/P/Skip Frame Interval/Period
 	{
@@ -1556,14 +1557,13 @@ bool Plugin::Interface::H264Interface::update(obs_data_t* data)
 		uint32_t fpsNum = m_VideoEncoder->GetFrameRate().first;
 		uint32_t fpsDen = m_VideoEncoder->GetFrameRate().second;
 		if (obs_data_get_int(data, "keyint_sec") > 0) {
-			m_VideoEncoder->SetIDRPeriod(
-				static_cast<uint32_t>(obs_data_get_int(data, "keyint_sec")
-									  * (static_cast<double_t>(fpsNum) / static_cast<double_t>(fpsDen))));
+			uint32_t idrperiod = static_cast<uint32_t>(obs_data_get_int(data, "keyint_sec")
+									  * (static_cast<double_t>(fpsNum) / static_cast<double_t>(fpsDen)));
+			m_VideoEncoder->SetIDRPeriod(idrperiod);
+			m_VideoEncoder->SetHeaderInsertionSpacing(idrperiod);
 
+			obs_data_set_int(data, P_PERIOD_IDR_H264, idrperiod);
 			obs_data_set_double(data, P_INTERVAL_KEYFRAME, static_cast<double_t>(obs_data_get_int(data, "keyint_sec")));
-			obs_data_set_int(data, P_PERIOD_IDR_H264,
-							 static_cast<uint32_t>(obs_data_get_int(data, "keyint_sec")
-												   * (static_cast<double_t>(fpsNum) / static_cast<double_t>(fpsDen))));
 			obs_data_unset_user_value(data, "keyint_sec");
 		}
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
SPS/PPS header insert
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When recording in m3u8 format using H264 / AVC encoder (AMD Advanced Media Framework), the second and subsequent TS files are broken.
Fixed second and subsequent TS files are broken.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with start recording in OBS Studio
### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix (non-breaking change which fixes an issue)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
