### PR TITLE
Add 2.5 second timeout for AMF test process

### DIFF
--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -144,6 +144,9 @@ MODULE_EXPORT bool obs_module_load(void)
 			CloseHandle(hRead);
 
 			switch (returnCode) {
+			case STATUS_TIMEOUT:
+				PLOG_ERROR("AMF Test timed out.");
+				return false;
 			case STATUS_ACCESS_VIOLATION:
 			case STATUS_ARRAY_BOUNDS_EXCEEDED:
 			case STATUS_BREAKPOINT:


### PR DESCRIPTION
### Description
Adds a 2.5 second timeout to the enc-amf-test on Windows, after which point the process self-terminates.

### Motivation and Context
Some users report the OBS UI failing to appear despite obs64.exe running. In one case, this was caused by the AMF test executable freezing, and OBS waiting forever on a pipe `ReadFile` call. Self-terminating the test executable seemed like an easier implementation than asynchronous pipe I/O and has the benefit of cleaning up the frozen process.

Yes, it is a bit hacky, but AMF is long overdue for a rewrite anyway.

Ref: https://github.com/obsproject/obs-studio/issues/6230

### How Has This Been Tested?
Ran enc-amf-test with hardcoded delays and verified it terminated and OBS reported a timeout.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
