### PR TITLE
amf: Deprecate legacy AMD encoder

### DIFF
--- a/source/enc-h264.cpp
+++ b/source/enc-h264.cpp
@@ -37,6 +37,7 @@ void Plugin::Interface::H264Interface::encoder_register()
 	_oei.type  = OBS_ENCODER_VIDEO;
 	_oei.id    = "amd_amf_h264";
 	_oei.codec = "h264";
+	_oei.caps  = OBS_ENCODER_CAP_DEPRECATED;
 
 	_oei.get_name       = get_name;
 	_oei.get_defaults   = get_defaults;

--- a/source/enc-h265.cpp
+++ b/source/enc-h265.cpp
@@ -34,6 +34,7 @@ void Plugin::Interface::H265Interface::encoder_register()
 	_oei.type  = OBS_ENCODER_VIDEO;
 	_oei.id    = "amd_amf_h265";
 	_oei.codec = "hevc";
+	_oei.caps  = OBS_ENCODER_CAP_DEPRECATED;
 
 	_oei.get_name       = get_name;
 	_oei.get_defaults   = get_defaults;


### PR DESCRIPTION

### Description

Add deprecated flag to encoder.

### Motivation and Context

Encoder has been replaced.

### How Has This Been Tested?

Testing?

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
