### PR TITLE
Suppress C4062 (switch) warnings (deps PR for obs-studio#6960)

### DIFF
--- a/source/amf-encoder-h265.cpp
+++ b/source/amf-encoder-h265.cpp
@@ -1375,6 +1375,8 @@ void Plugin::AMD::EncoderH265::PacketPriorityAndKeyframe(amf::AMFDataPtr& pData,
 {
 	uint64_t pktType;
 	pData->GetProperty(AMF_VIDEO_ENCODER_HEVC_OUTPUT_DATA_TYPE, &pktType);
+#pragma warning(push)
+#pragma warning(disable : 4062)
 	switch ((AMF_VIDEO_ENCODER_HEVC_OUTPUT_DATA_TYPE_ENUM)pktType) {
 	case AMF_VIDEO_ENCODER_HEVC_OUTPUT_DATA_TYPE_I:
 		packet->keyframe = true;
@@ -1384,6 +1386,7 @@ void Plugin::AMD::EncoderH265::PacketPriorityAndKeyframe(amf::AMFDataPtr& pData,
 		packet->priority = 0;
 		break;
 	}
+#pragma warning(pop)
 }
 
 AMF_RESULT Plugin::AMD::EncoderH265::GetExtraDataInternal(amf::AMFVariant* p)

--- a/source/amf-encoder.cpp
+++ b/source/amf-encoder.cpp
@@ -122,6 +122,8 @@ Plugin::AMD::Encoder::Encoder(Codec codec, std::shared_ptr<API::IAPI> videoAPI, 
 	case API::Type::Direct3D9:
 		break;
 	default:
+#pragma warning(push)
+#pragma warning(disable : 4062)
 		m_API = API::GetAPI(0);
 		switch (m_API->GetType()) {
 		case API::Type::Direct3D9:
@@ -144,6 +146,7 @@ Plugin::AMD::Encoder::Encoder(Codec codec, std::shared_ptr<API::IAPI> videoAPI, 
 		res             = m_AMFContext->InitDX11(m_APIDevice->GetContext());
 		break;
 	}
+#pragma warning(pop)
 	if (res != AMF_OK) {
 		QUICK_FORMAT_MESSAGE(errMsg, "<Id: %llu> Initializing %s API with Adapter '%s' failed, error %ls (code %d).",
 							 m_UniqueId, m_API->GetName().c_str(), m_APIAdapter.Name.c_str(),

--- a/source/enc-h264.cpp
+++ b/source/enc-h264.cpp
@@ -713,6 +713,8 @@ try {
 	if (preset != Presets::None)
 		result = true;
 
+#pragma warning(push)
+#pragma warning(disable : 4062)
 	switch (preset) {
 	case Presets::ResetToDefaults:
 #pragma region Default
@@ -1318,6 +1320,7 @@ Plugin::Interface::H264Interface::H264Interface(obs_data_t* data, obs_encoder_t*
 		colorSpace = ColorSpace::SRGB;
 		break;
 	}
+#pragma warning(pop)
 
 	auto api = API::GetAPI(obs_data_get_string(data, P_VIDEO_API));
 	union {

--- a/source/enc-h265.cpp
+++ b/source/enc-h265.cpp
@@ -839,6 +839,8 @@ Plugin::Interface::H265Interface::H265Interface(obs_data_t* data, obs_encoder_t*
 	Plugin::AMD::AMF::Instance()->EnableDebugTrace(debug);
 
 	ColorFormat colorFormat = ColorFormat::NV12;
+#pragma warning(push)
+#pragma warning(disable : 4062)
 	switch (voi->format) {
 	case VIDEO_FORMAT_NV12:
 		colorFormat = ColorFormat::NV12;
@@ -872,6 +874,7 @@ Plugin::Interface::H265Interface::H265Interface(obs_data_t* data, obs_encoder_t*
 		colorSpace = ColorSpace::SRGB;
 		break;
 	}
+#pragma warning(pop)
 
 	auto api = API::GetAPI(obs_data_get_string(data, P_VIDEO_API));
 	union {

--- a/source/utility.cpp
+++ b/source/utility.cpp
@@ -422,6 +422,8 @@ AMF_VIDEO_ENCODER_PROFILE_ENUM Utility::ProfileToAMFH264(Plugin::AMD::Profile v)
 Plugin::AMD::Profile Utility::ProfileFromAMFH264(AMF_VIDEO_ENCODER_PROFILE_ENUM v)
 {
 #pragma warning(disable : 4063) // Developer Note: I know better, Compiler.
+#pragma warning(push)
+#pragma warning(disable : 4062)
 	switch (v) {
 	case AMF_VIDEO_ENCODER_PROFILE_CONSTRAINED_BASELINE:
 		return Profile::ConstrainedBaseline;
@@ -629,6 +631,7 @@ Plugin::AMD::RateControlMethod Utility::RateControlMethodFromAMFH265(AMF_VIDEO_E
 	case AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR:
 		return RateControlMethod::LatencyConstrainedVariableBitrate;
 	}
+#pragma warning(pop)
 	throw std::runtime_error("Invalid Parameter");
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

https://github.com/obsproject/obs-studio/pull/6960 enables C4062 for parity with Clang and GCC.

This just add pragmas to suppress switch warnings.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Required by https://github.com/obsproject/obs-studio/pull/6960

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

CI of https://github.com/obsproject/obs-studio/pull/6960 no longer fail because of this plugin.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- Workaround

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
