### PR TITLE
cmake: Update CMake files for build system 3.0 update

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -1,0 +1,46 @@
+{
+  "format": {
+    "line_width": 120,
+    "tab_size": 2,
+    "enable_sort": true,
+    "autosort": true
+  },
+  "additional_commands": {
+    "find_qt": {
+      "flags": [],
+      "kwargs": {
+        "COMPONENTS": "+",
+        "COMPONENTS_WIN": "+",
+        "COMPONENTS_MACOS": "+",
+        "COMPONENTS_LINUX": "+"
+      }
+    },
+    "set_target_properties_obs": {
+      "pargs": 1,
+      "flags": [],
+      "kwargs": {
+        "PROPERTIES": {
+          "kwargs": {
+            "PREFIX": 1,
+            "OUTPUT_NAME": 1,
+            "FOLDER": 1,
+            "VERSION": 1,
+            "SOVERSION": 1,
+            "FRAMEWORK": 1,
+            "BUNDLE": 1,
+            "AUTOMOC": 1,
+            "AUTOUIC": 1,
+            "AUTORCC": 1,
+            "AUTOUIC_SEARCH_PATHS": 1,
+            "BUILD_RPATH": 1,
+            "INSTALL_RPATH": 1,
+            "XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC": 1,
+            "XCODE_ATTRIBUTE_CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION": 1,
+            "XCODE_ATTRIBUTE_GCC_WARN_SHADOW":1 ,
+            "LIBRARY_OUTPUT_DIRECTORY": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,471 +1,57 @@
-# A Plugin that integrates the AMD AMF encoder into OBS Studio
-# Copyright (C) 2016 - 2017 Michael Fabian Dirks
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+cmake_minimum_required(VERSION 3.24...3.25)
 
-# CMake Setup
-CMake_Minimum_Required(VERSION 3.1.0)
-Include("cmake/util.cmake")
+legacy_check()
 
-# Automatic Versioning
-Set(VERSION_MAJOR 2)
-Set(VERSION_MINOR 7)
-Set(VERSION_PATCH 0)
-Set(VERSION_TWEAK 0)
-Set(PROJECT_COMMIT "N/A")
-If(EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git")
-	Set(GIT_RESULT "")
-	Set(GIT_OUTPUT "")
-	EXECUTE_PROCESS(
-		COMMAND git rev-list --count --topo-order ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}..HEAD
-		WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-		RESULT_VARIABLE GIT_RESULT
-		OUTPUT_VARIABLE GIT_OUTPUT
-		OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE ERROR_QUIET
-	)
-	If(GIT_RESULT EQUAL 0)
-		Set(VERSION_TWEAK ${GIT_OUTPUT})
-	EndIf()
-	EXECUTE_PROCESS(
-		COMMAND git rev-parse HEAD
-		WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-		RESULT_VARIABLE GIT_RESULT
-		OUTPUT_VARIABLE GIT_OUTPUT
-		OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE ERROR_QUIET
-	)
-	If(GIT_RESULT EQUAL 0)
-		Set(PROJECT_COMMIT ${GIT_OUTPUT})
-	EndIf()
-EndIf()
+add_library(enc-amf MODULE)
+add_library(OBS::enc-amf ALIAS enc-amf)
 
-# Define Project
-PROJECT(
-	enc-amf
-	VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.${VERSION_TWEAK}
-)
+target_sources(
+  enc-amf
+  PRIVATE include/amf.hpp
+          include/amf-capabilities.hpp
+          include/amf-encoder.hpp
+          include/amf-encoder-h264.hpp
+          include/enc-h264.hpp
+          include/amf-encoder-h265.hpp
+          include/enc-h265.hpp
+          include/api-base.hpp
+          include/api-host.hpp
+          include/api-opengl.hpp
+          include/utility.hpp
+          include/plugin.hpp
+          include/strings.hpp
+          source/amf.cpp
+          source/amf-capabilities.cpp
+          source/amf-encoder.cpp
+          source/amf-encoder-h264.cpp
+          source/enc-h264.cpp
+          source/amf-encoder-h265.cpp
+          source/enc-h265.cpp
+          source/api-base.cpp
+          source/api-host.cpp
+          source/api-opengl.cpp
+          source/utility.cpp
+          source/plugin.cpp
+          include/api-d3d9.hpp
+          include/api-d3d11.hpp
+          source/api-d3d9.cpp
+          source/api-d3d11.cpp)
 
-################################################################################
-# CMake / Compiler
-################################################################################
+target_include_directories(enc-amf PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                                           "${CMAKE_CURRENT_SOURCE_DIR}/AMF/amf/public/include")
 
-# Detect Build Type
-If("${CMAKE_SOURCE_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
-	Set(PropertyPrefix "")
-Else()
-	Set(PropertyPrefix "${PROJECT_NAME}_")
-EndIf()
+set(_VERSION_MAJOR 2)
+set(_VERSION_MINOR 7)
+set(_VERSION_PATCH 0)
 
-# Detect Architecture
-math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
-IF("${BITS}" STREQUAL "32")
-	SET(ARCH "x86")
-Else()
-	SET(ARCH "x64")
-ENDIF()
+configure_file(include/version.hpp.in version.hpp)
+target_sources(enc-amf PRIVATE version.hpp)
 
-# Configure Installer script
-Configure_File(
-	"${PROJECT_SOURCE_DIR}/ci/installer.in.iss"
-	"${PROJECT_BINARY_DIR}/ci/installer.iss"
-)
+configure_file(cmake/windows/obs-module.rc.in enc-amf.rc)
+target_sources(enc-amf PRIVATE enc-amf.rc)
 
-# Configure Version Header
-Configure_File(
-	"${PROJECT_SOURCE_DIR}/include/version.hpp.in"
-	"${PROJECT_BINARY_DIR}/include/version.hpp"
-)
+target_compile_options(enc-amf PRIVATE /wd4828)
 
-# Windows Specific Resource Definition
-If(WIN32)
-	Set(PROJECT_PRODUCT_NAME "OBS Studio AMD Encoder")
-	Set(PROJECT_DESCRIPTION "")
-	Set(PROJECT_COMPANY_NAME "Xaymar")
-	Set(PROJECT_COPYRIGHT "Xaymar © 2016 - 2018")
-	Set(PROJECT_LEGAL_TRADEMARKS_1 "Advanced Micro Devices, AMD, AMD Ryzen, Ryzen, AMD Radeon and Radeon are Trademarks of Advanced Micro Devices.")
-	Set(PROJECT_LEGAL_TRADEMARKS_2 "")
-	Set(PROJECT_DESCRIPTION "AMD Encoder integration for OBS Studio")
+target_link_libraries(enc-amf PRIVATE OBS::libobs version winmm)
 
-	Configure_File(
-		"${PROJECT_SOURCE_DIR}/cmake/version.rc.in"
-		"${PROJECT_BINARY_DIR}/cmake/version.rc"
-		@ONLY
-	)
-EndIf()
-
-# All Warnings, Extra Warnings, Pedantic
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	# using Clang
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-missing-braces -Wmissing-field-initializers -Wno-c++98-compat-pedantic -Wold-style-cast -Wno-documentation -Wno-documentation-unknown-command -Wno-covered-switch-default -Wno-switch-enum")
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	# GCC: -fpermissive is required as GCC does not allow the same template to be in different namespaces.
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -fpermissive -Wno-long-long -Wno-missing-braces -Wmissing-field-initializers")
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-	# using Intel C++
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-	# Force to always compile with W4
-	if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
-		string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-	else()
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-	endif()
-endif()
-# C++ Standard and Extensions
-## Use C++17 and no non-standard extensions.
-set(_CXX_STANDARD 17)
-set(_CXX_EXTENSIONS OFF)
-
-math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
-
-################################################################################
-# Options
-################################################################################
-set(${PropertyPrefix}OBS_NATIVE FALSE CACHE BOOL "Use native obs-studio build" FORCE)
-set(${PropertyPrefix}OBS_REFERENCE FALSE CACHE BOOL "Use referenced obs-studio build" FORCE)
-set(${PropertyPrefix}OBS_PACKAGE FALSE CACHE BOOL "Use packaged obs-studio build" FORCE)
-set(${PropertyPrefix}OBS_DOWNLOAD FALSE CACHE BOOL "Use downloaded obs-studio build" FORCE)
-mark_as_advanced(FORCE OBS_NATIVE OBS_PACKAGE OBS_REFERENCE OBS_DOWNLOAD)
-
-if(NOT TARGET libobs)
-	set(${PropertyPrefix}OBS_STUDIO_DIR "" CACHE PATH "OBS Studio Source/Package Directory")
-	set(${PropertyPrefix}OBS_DOWNLOAD_VERSION "24.0.1-ci" CACHE STRING "OBS Studio Version to download")
-endif()
-
-if(NOT ${PropertyPrefix}OBS_NATIVE)
-	set(${PropertyPrefix}OBS_DEPENDENCIES_DIR "" CACHE PATH "Path to OBS Dependencies")
-	set(CMAKE_PACKAGE_PREFIX "${CMAKE_BINARY_DIR}" CACHE PATH "Path for generated archives.")
-	set(CMAKE_PACKAGE_NAME "${PROJECT_NAME}" CACHE STRING "Name for the generated archives.")
-	set(CMAKE_PACKAGE_SUFFIX_OVERRIDE "" CACHE STRING "Override for the suffix.")
-endif()
-
-################################################################################
-# Dependencies
-################################################################################
-
-# Detect OBS Studio Type
-if(TARGET libobs)
-	message(STATUS "${PROJECT_NAME}: Using native obs-studio.")
-	CacheSet(${PropertyPrefix}OBS_NATIVE TRUE)
-else()
-	CacheSet(${PropertyPrefix}OBS_NATIVE FALSE)
-	if(EXISTS "${OBS_STUDIO_DIR}/cmake/LibObs/LibObsConfig.cmake")
-		message(STATUS "${PROJECT_NAME}: Using packaged obs-studio.")
-		CacheSet(${PropertyPrefix}OBS_PACKAGE TRUE)
-	elseif(EXISTS "${OBS_STUDIO_DIR}/libobs/obs-module.h")
-		message(STATUS "${PROJECT_NAME}: Using referenced obs-studio.")
-		CacheSet(${PropertyPrefix}OBS_REFERENCE TRUE)
-	else()
-		message(STATUS "${PROJECT_NAME}: No OBS Studio detected, using downloadable prebuilt binaries.")
-		CacheSet(${PropertyPrefix}OBS_DOWNLOAD TRUE)
-		if (WIN32)
-			set(${PropertyPrefix}OBS_DOWNLOAD_URL "https://github.com/Xaymar/obs-studio/releases/download/${OBS_DOWNLOAD_VERSION}/obs-studio-${ARCH}-0.0.0.0-vs2017.7z")
-		elseif(UNIX)
-			set(${PropertyPrefix}OBS_DOWNLOAD_URL "https://github.com/Xaymar/obs-studio/releases/download/${OBS_DOWNLOAD_VERSION}/obs-studio-${ARCH}-0.0.0.0-gcc.7z")
-		endif()
-	endif()
-endif()
-
-If(NOT ${PropertyPrefix}OBS_NATIVE)
-	Set(CMAKE_PACKAGE_PREFIX "${CMAKE_BINARY_DIR}" CACHE PATH "Path for generated archives.")
-	Set(CMAKE_PACKAGE_NAME "${PROJECT_NAME}" CACHE STRING "Name for the generated archives.")
-	Set(CMAKE_PACKAGE_SUFFIX_OVERRIDE "" CACHE STRING "Override for the suffix.")
-EndIf()
-
-# CMake Modules
-If(${PropertyPrefix}OBS_DOWNLOAD)
-	Include("cmake/DownloadProject.cmake")
-EndIf()
-If(NOT ${PropertyPrefix}OBS_NATIVE)
-	Include("cmake/cppcheck.cmake")
-EndIf()
-
-# Load OBS Studio
-If(${PropertyPrefix}OBS_NATIVE)
-	Option(BUILD_AMD_ENCODER "Build AMD Encoder module" ON)
-	If (NOT BUILD_AMD_ENCODER)
-		Message(STATUS "Not building AMD Encoder")
-		Return()
-	EndIf()
-ElseIf(${PropertyPrefix}OBS_PACKAGE)
-	Include("${OBS_STUDIO_DIR}/cmake/LibObs/LibObsConfig.cmake")
-ElseIf(${PropertyPrefix}OBS_REFERENCE)
-	Set(obsPath "${OBS_STUDIO_DIR}")
-	Include("${OBS_STUDIO_DIR}/cmake/external/Findlibobs.cmake")
-ElseIf(${PropertyPrefix}OBS_DOWNLOAD)
-	download_project(
-		PROJ libobs
-		URL ${OBS_DOWNLOAD_URL}
-		UPDATE_DISCONNECTED 1
-	)
-	INCLUDE("${libobs_SOURCE_DIR}/cmake/LibObs/LibObsConfig.cmake")
-Else()
-	Message(CRITICAL "Impossible case reached, very system stability.")
-	Return()
-EndIf()
-
-################################################################################
-# Code
-################################################################################
-Set(PROJECT_HEADERS
-	"${PROJECT_SOURCE_DIR}/include/amf.hpp"
-	"${PROJECT_SOURCE_DIR}/include/amf-capabilities.hpp"
-	"${PROJECT_SOURCE_DIR}/include/amf-encoder.hpp"
-	"${PROJECT_SOURCE_DIR}/include/amf-encoder-h264.hpp"
-	"${PROJECT_SOURCE_DIR}/include/enc-h264.hpp"
-	"${PROJECT_SOURCE_DIR}/include/amf-encoder-h265.hpp"
-	"${PROJECT_SOURCE_DIR}/include/enc-h265.hpp"
-	"${PROJECT_SOURCE_DIR}/include/api-base.hpp"
-	"${PROJECT_SOURCE_DIR}/include/api-host.hpp"
-	"${PROJECT_SOURCE_DIR}/include/api-opengl.hpp"
-	"${PROJECT_SOURCE_DIR}/include/utility.hpp"
-	"${PROJECT_SOURCE_DIR}/include/plugin.hpp"
-	"${PROJECT_SOURCE_DIR}/include/strings.hpp"
-	"${PROJECT_BINARY_DIR}/include/version.hpp"
-)
-Set(PROJECT_SOURCES
-	"${PROJECT_SOURCE_DIR}/source/amf.cpp"
-	"${PROJECT_SOURCE_DIR}/source/amf-capabilities.cpp"
-	"${PROJECT_SOURCE_DIR}/source/amf-encoder.cpp"
-	"${PROJECT_SOURCE_DIR}/source/amf-encoder-h264.cpp"
-	"${PROJECT_SOURCE_DIR}/source/enc-h264.cpp"
-	"${PROJECT_SOURCE_DIR}/source/amf-encoder-h265.cpp"
-	"${PROJECT_SOURCE_DIR}/source/enc-h265.cpp"
-	"${PROJECT_SOURCE_DIR}/source/api-base.cpp"
-	"${PROJECT_SOURCE_DIR}/source/api-host.cpp"
-	"${PROJECT_SOURCE_DIR}/source/api-opengl.cpp"
-	"${PROJECT_SOURCE_DIR}/source/utility.cpp"
-	"${PROJECT_SOURCE_DIR}/source/plugin.cpp"
-)
-Set(PROJECT_DATA
-	"${PROJECT_SOURCE_DIR}/resources/locale/en-US.ini"
-	"${PROJECT_SOURCE_DIR}/LICENSE"
-)
-Set(PROJECT_LIBRARIES
-	version
-	winmm
-)
-
-If(WIN32) # Windows Only
-	LIST(APPEND PROJECT_HEADERS
-		"include/api-d3d9.hpp"
-		"include/api-d3d11.hpp"
-	)
-	LIST(APPEND PROJECT_SOURCES
-		"source/api-d3d9.cpp"
-		"source/api-d3d11.cpp"
-		"${PROJECT_BINARY_DIR}/cmake/version.rc"
-	)
-EndIf()
-
-# Source Grouping
-Source_Group("Data Files" FILES ${enc-amf_DATA})
-
-################################################################################
-# Target
-################################################################################
-
-Add_Library(${PROJECT_NAME} MODULE
-	${PROJECT_HEADERS}
-	${PROJECT_SOURCES}
-	${PROJECT_DATA}
-)
-If(${PropertyPrefix}OBS_NATIVE)
-	Set_Target_Properties(${PROJECT_NAME} PROPERTIES FOLDER "plugins/enc-amf")
-EndIf()
-
-# Include Directories
-Target_Include_Directories(${PROJECT_NAME}
-	PUBLIC
-		"${PROJECT_BINARY_DIR}/include"
-		"${PROJECT_SOURCE_DIR}/include"
-		"${PROJECT_SOURCE_DIR}/AMF/amf/public/include"
-	PRIVATE
-		"${PROJECT_BINARY_DIR}/source"
-		"${PROJECT_SOURCE_DIR}/source"
-		"${PROJECT_BINARY_DIR}"
-		"${PROJECT_SOURCE_DIR}"
-		"${CMAKE_SOURCE_DIR}"
-)
-
-# OBS Studio
-If(${PropertyPrefix}OBS_NATIVE)
-	Target_Link_Libraries(${PROJECT_NAME}
-		libobs
-	)
-ElseIf(${PropertyPrefix}OBS_REFERENCE)
-	Target_Include_Directories(${PROJECT_NAME}
-		PRIVATE
-			"${OBS_STUDIO_DIR}/libobs"
-	)
-	Target_Link_Libraries(${PROJECT_NAME}
-		"${LIBOBS_LIB}"
-	)
-ElseIf(${PropertyPrefix}OBS_PACKAGE)
-	Target_Include_Directories(${PROJECT_NAME}
-		PRIVATE
-			"${OBS_STUDIO_DIR}/include"
-	)
-	Target_Link_Libraries(${PROJECT_NAME}
-		libobs
-	)
-ElseIf(${PropertyPrefix}OBS_DOWNLOAD)
-	Target_Link_Libraries(${PROJECT_NAME}
-		libobs
-	)
-EndIf()
-
-# Link Libraries
-Target_Link_Libraries(${PROJECT_NAME}
-	"${PROJECT_LIBRARIES}"
-)
-
-# Definitions
-If (WIN32)
-	Target_Compile_Definitions(${PROJECT_NAME}
-		PRIVATE
-			_CRT_SECURE_NO_WARNINGS
-			# windows.h
-			WIN32_LEAN_AND_MEAN
-			NOGPICAPMASKS
-			NOVIRTUALKEYCODES
-			#NOWINMESSAGES
-			NOWINSTYLES
-			NOSYSMETRICS
-			NOMENUS
-			NOICONS
-			NOKEYSTATES
-			NOSYSCOMMANDS
-			NORASTEROPS
-			NOSHOWWINDOW
-			NOATOM
-			NOCLIPBOARD
-			NOCOLOR
-			NOCTLMGR
-			NODRAWTEXT
-			#NOGDI
-			NOKERNEL
-			#NOUSER
-			#NONLS
-			NOMB
-			NOMEMMGR
-			NOMETAFILE
-			NOMINMAX
-			#NOMSG
-			NOOPENFILE
-			NOSCROLL
-			NOSERVICE
-			NOSOUND
-			#NOTEXTMETRIC
-			NOWH
-			NOWINOFFSETS
-			NOCOMM
-			NOKANJI
-			NOHELP
-			NOPROFILER
-			NODEFERWINDOWPOS
-			NOMCX
-			NOIME
-			NOMDI
-			NOINOUT
-	)
-EndIf()
-
-# File Version
-If(WIN32)
-	Set_Target_Properties(
-		${PROJECT_NAME}
-		PROPERTIES
-		VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_TWEAK}
-		SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_TWEAK}
-	)
-Else()
-	Set_Target_Properties(
-		${PROJECT_NAME}
-		PROPERTIES
-		VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_TWEAK}
-		SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_TWEAK}
-	)
-EndIf()
-
-# CPPCheck
-If(NOT ${PropertyPrefix}OBS_NATIVE)
-	SET(excludes )
-	LIST(APPEND excludes "${PROJECT_SOURCE_DIR}/AMF")
-	If(${PropertyPrefix}OBS_REFERENCE)
-		LIST(APPEND excludes "${OBS_STUDIO_DIR}/libobs")
-	ElseIf(${PropertyPrefix}OBS_PACKAGE)
-		LIST(APPEND excludes "${OBS_STUDIO_DIR}/libobs")
-	ElseIf(${PropertyPrefix}OBS_DOWNLOAD)
-		LIST(APPEND excludes "${libobs_SOURCE_DIR}")
-	EndIf()
-
-	CppCheck(
-		EXCLUDE ${excludes}
-	)
-	CppCheck_Add_Project(${PROJECT_NAME})
-EndIf()
-
-################################################################################
-# Installation
-################################################################################
-
-If(${PropertyPrefix}OBS_NATIVE)
-	install_obs_plugin_with_data(${PROJECT_NAME} resources)
-Else()
-	Install(
-		TARGETS ${PROJECT_NAME}
-		RUNTIME DESTINATION "./obs-plugins/${BITS}bit/" COMPONENT Runtime
-		LIBRARY DESTINATION "./obs-plugins/${BITS}bit/" COMPONENT Runtime
-	)
-	IF(MSVC)
-		Install(
-			FILES $<TARGET_PDB_FILE:${PROJECT_NAME}>
-			DESTINATION "./obs-plugins/${BITS}bit/"
-			OPTIONAL
-		)
-	ENDIF()
-
-	Install(
-		DIRECTORY "${PROJECT_SOURCE_DIR}/resources/"
-		DESTINATION "./data/obs-plugins/${PROJECT_NAME}/"
-	)
-
-	If("${CMAKE_PACKAGE_SUFFIX_OVERRIDE}" STREQUAL "")
-		Set(PackageFullName "${CMAKE_PACKAGE_PREFIX}/${CMAKE_PACKAGE_NAME}-${PROJECT_VERSION}")
-	Else()
-		Set(PackageFullName "${CMAKE_PACKAGE_PREFIX}/${CMAKE_PACKAGE_NAME}-${CMAKE_PACKAGE_SUFFIX_OVERRIDE}")
-	EndIf()
-
-	Add_Custom_Target(
-		PACKAGE_7Z
-		${CMAKE_COMMAND} -E tar cfv "${PackageFullName}.7z" --format=7zip --
-			"${CMAKE_INSTALL_PREFIX}/obs-plugins"
-			"${CMAKE_INSTALL_PREFIX}/data"
-		WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}"
-	)
-	Add_Custom_Target(
-		PACKAGE_ZIP
-		${CMAKE_COMMAND} -E tar cfv "${PackageFullName}.zip" --format=zip --
-			"${CMAKE_INSTALL_PREFIX}/obs-plugins"
-			"${CMAKE_INSTALL_PREFIX}/data"
-		WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}"
-	)
-EndIf()
-
-################################################################################
-# Child Projects
-################################################################################
-
-# Sub Project
-Add_SubDirectory(amf-test)
+set_target_properties_obs(enc-amf PROPERTIES PREFIX "" FOLDER plugins)

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -1,0 +1,440 @@
+# A Plugin that integrates the AMD AMF encoder into OBS Studio Copyright (C) 2016 - 2017 Michael Fabian Dirks
+#
+# This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
+# CMake Setup
+cmake_minimum_required(VERSION 3.1.0)
+include("cmake/util.cmake")
+
+# Automatic Versioning
+set(VERSION_MAJOR 2)
+set(VERSION_MINOR 7)
+set(VERSION_PATCH 0)
+set(VERSION_TWEAK 0)
+set(PROJECT_COMMIT "N/A")
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git")
+  set(GIT_RESULT "")
+  set(GIT_OUTPUT "")
+  execute_process(
+    COMMAND git rev-list --count --topo-order ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}..HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    RESULT_VARIABLE GIT_RESULT
+    OUTPUT_VARIABLE GIT_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+  if(GIT_RESULT EQUAL 0)
+    set(VERSION_TWEAK ${GIT_OUTPUT})
+  endif()
+  execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    RESULT_VARIABLE GIT_RESULT
+    OUTPUT_VARIABLE GIT_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+  if(GIT_RESULT EQUAL 0)
+    set(PROJECT_COMMIT ${GIT_OUTPUT})
+  endif()
+endif()
+
+# Define Project
+project(enc-amf VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.${VERSION_TWEAK})
+
+# ######################################################################################################################
+# CMake / Compiler
+# ######################################################################################################################
+
+# Detect Build Type
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
+  set(PropertyPrefix "")
+else()
+  set(PropertyPrefix "${PROJECT_NAME}_")
+endif()
+
+# Detect Architecture
+math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
+if("${BITS}" STREQUAL "32")
+  set(ARCH "x86")
+else()
+  set(ARCH "x64")
+endif()
+
+# Configure Installer script
+configure_file("${PROJECT_SOURCE_DIR}/ci/installer.in.iss" "${PROJECT_BINARY_DIR}/ci/installer.iss")
+
+# Configure Version Header
+configure_file("${PROJECT_SOURCE_DIR}/include/version.hpp.in" "${PROJECT_BINARY_DIR}/include/version.hpp")
+
+# Windows Specific Resource Definition
+if(WIN32)
+  set(PROJECT_PRODUCT_NAME "OBS Studio AMD Encoder")
+  set(PROJECT_DESCRIPTION "")
+  set(PROJECT_COMPANY_NAME "Xaymar")
+  set(PROJECT_COPYRIGHT "Xaymar © 2016 - 2018")
+  set(PROJECT_LEGAL_TRADEMARKS_1
+      "Advanced Micro Devices, AMD, AMD Ryzen, Ryzen, AMD Radeon and Radeon are Trademarks of Advanced Micro Devices.")
+  set(PROJECT_LEGAL_TRADEMARKS_2 "")
+  set(PROJECT_DESCRIPTION "AMD Encoder integration for OBS Studio")
+
+  configure_file("${PROJECT_SOURCE_DIR}/cmake/version.rc.in" "${PROJECT_BINARY_DIR}/cmake/version.rc" @ONLY)
+endif()
+
+# All Warnings, Extra Warnings, Pedantic
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  # using Clang
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -Wall -Wno-missing-braces -Wmissing-field-initializers -Wno-c++98-compat-pedantic -Wold-style-cast -Wno-documentation -Wno-documentation-unknown-command -Wno-covered-switch-default -Wno-switch-enum"
+  )
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  # GCC: -fpermissive is required as GCC does not allow the same template to be in different namespaces.
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -fpermissive -Wno-long-long -Wno-missing-braces -Wmissing-field-initializers"
+  )
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+  # using Intel C++
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  # Force to always compile with W4
+  if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+    string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+  endif()
+endif()
+# C++ Standard and Extensions Use C++17 and no non-standard extensions.
+set(_CXX_STANDARD 17)
+set(_CXX_EXTENSIONS OFF)
+
+math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
+
+# ######################################################################################################################
+# Options
+# ######################################################################################################################
+set(${PropertyPrefix}OBS_NATIVE
+    FALSE
+    CACHE BOOL "Use native obs-studio build" FORCE)
+set(${PropertyPrefix}OBS_REFERENCE
+    FALSE
+    CACHE BOOL "Use referenced obs-studio build" FORCE)
+set(${PropertyPrefix}OBS_PACKAGE
+    FALSE
+    CACHE BOOL "Use packaged obs-studio build" FORCE)
+set(${PropertyPrefix}OBS_DOWNLOAD
+    FALSE
+    CACHE BOOL "Use downloaded obs-studio build" FORCE)
+mark_as_advanced(FORCE OBS_NATIVE OBS_PACKAGE OBS_REFERENCE OBS_DOWNLOAD)
+
+if(NOT TARGET libobs)
+  set(${PropertyPrefix}OBS_STUDIO_DIR
+      ""
+      CACHE PATH "OBS Studio Source/Package Directory")
+  set(${PropertyPrefix}OBS_DOWNLOAD_VERSION
+      "24.0.1-ci"
+      CACHE STRING "OBS Studio Version to download")
+endif()
+
+if(NOT ${PropertyPrefix}OBS_NATIVE)
+  set(${PropertyPrefix}OBS_DEPENDENCIES_DIR
+      ""
+      CACHE PATH "Path to OBS Dependencies")
+  set(CMAKE_PACKAGE_PREFIX
+      "${CMAKE_BINARY_DIR}"
+      CACHE PATH "Path for generated archives.")
+  set(CMAKE_PACKAGE_NAME
+      "${PROJECT_NAME}"
+      CACHE STRING "Name for the generated archives.")
+  set(CMAKE_PACKAGE_SUFFIX_OVERRIDE
+      ""
+      CACHE STRING "Override for the suffix.")
+endif()
+
+# ######################################################################################################################
+# Dependencies
+# ######################################################################################################################
+
+# Detect OBS Studio Type
+if(TARGET libobs)
+  message(STATUS "${PROJECT_NAME}: Using native obs-studio.")
+  cacheset(${PropertyPrefix}OBS_NATIVE TRUE)
+else()
+  cacheset(${PropertyPrefix}OBS_NATIVE FALSE)
+  if(EXISTS "${OBS_STUDIO_DIR}/cmake/LibObs/LibObsConfig.cmake")
+    message(STATUS "${PROJECT_NAME}: Using packaged obs-studio.")
+    cacheset(${PropertyPrefix}OBS_PACKAGE TRUE)
+  elseif(EXISTS "${OBS_STUDIO_DIR}/libobs/obs-module.h")
+    message(STATUS "${PROJECT_NAME}: Using referenced obs-studio.")
+    cacheset(${PropertyPrefix}OBS_REFERENCE TRUE)
+  else()
+    message(STATUS "${PROJECT_NAME}: No OBS Studio detected, using downloadable prebuilt binaries.")
+    cacheset(${PropertyPrefix}OBS_DOWNLOAD TRUE)
+    if(WIN32)
+      set(${PropertyPrefix}OBS_DOWNLOAD_URL
+          "https://github.com/Xaymar/obs-studio/releases/download/${OBS_DOWNLOAD_VERSION}/obs-studio-${ARCH}-0.0.0.0-vs2017.7z"
+      )
+    elseif(UNIX)
+      set(${PropertyPrefix}OBS_DOWNLOAD_URL
+          "https://github.com/Xaymar/obs-studio/releases/download/${OBS_DOWNLOAD_VERSION}/obs-studio-${ARCH}-0.0.0.0-gcc.7z"
+      )
+    endif()
+  endif()
+endif()
+
+if(NOT ${PropertyPrefix}OBS_NATIVE)
+  set(CMAKE_PACKAGE_PREFIX
+      "${CMAKE_BINARY_DIR}"
+      CACHE PATH "Path for generated archives.")
+  set(CMAKE_PACKAGE_NAME
+      "${PROJECT_NAME}"
+      CACHE STRING "Name for the generated archives.")
+  set(CMAKE_PACKAGE_SUFFIX_OVERRIDE
+      ""
+      CACHE STRING "Override for the suffix.")
+endif()
+
+# CMake Modules
+if(${PropertyPrefix}OBS_DOWNLOAD)
+  include("cmake/DownloadProject.cmake")
+endif()
+if(NOT ${PropertyPrefix}OBS_NATIVE)
+  include("cmake/cppcheck.cmake")
+endif()
+
+# Load OBS Studio
+if(${PropertyPrefix}OBS_NATIVE)
+  option(BUILD_AMD_ENCODER "Build AMD Encoder module" ON)
+  if(NOT BUILD_AMD_ENCODER)
+    message(STATUS "Not building AMD Encoder")
+    return()
+  endif()
+elseif(${PropertyPrefix}OBS_PACKAGE)
+  include("${OBS_STUDIO_DIR}/cmake/LibObs/LibObsConfig.cmake")
+elseif(${PropertyPrefix}OBS_REFERENCE)
+  set(obsPath "${OBS_STUDIO_DIR}")
+  include("${OBS_STUDIO_DIR}/cmake/external/Findlibobs.cmake")
+elseif(${PropertyPrefix}OBS_DOWNLOAD)
+  download_project(PROJ libobs URL ${OBS_DOWNLOAD_URL} UPDATE_DISCONNECTED 1)
+  include("${libobs_SOURCE_DIR}/cmake/LibObs/LibObsConfig.cmake")
+else()
+  message(CRITICAL "Impossible case reached, very system stability.")
+  return()
+endif()
+
+# ######################################################################################################################
+# Code
+# ######################################################################################################################
+set(PROJECT_HEADERS
+    "${PROJECT_SOURCE_DIR}/include/amf.hpp"
+    "${PROJECT_SOURCE_DIR}/include/amf-capabilities.hpp"
+    "${PROJECT_SOURCE_DIR}/include/amf-encoder.hpp"
+    "${PROJECT_SOURCE_DIR}/include/amf-encoder-h264.hpp"
+    "${PROJECT_SOURCE_DIR}/include/enc-h264.hpp"
+    "${PROJECT_SOURCE_DIR}/include/amf-encoder-h265.hpp"
+    "${PROJECT_SOURCE_DIR}/include/enc-h265.hpp"
+    "${PROJECT_SOURCE_DIR}/include/api-base.hpp"
+    "${PROJECT_SOURCE_DIR}/include/api-host.hpp"
+    "${PROJECT_SOURCE_DIR}/include/api-opengl.hpp"
+    "${PROJECT_SOURCE_DIR}/include/utility.hpp"
+    "${PROJECT_SOURCE_DIR}/include/plugin.hpp"
+    "${PROJECT_SOURCE_DIR}/include/strings.hpp"
+    "${PROJECT_BINARY_DIR}/include/version.hpp")
+set(PROJECT_SOURCES
+    "${PROJECT_SOURCE_DIR}/source/amf.cpp"
+    "${PROJECT_SOURCE_DIR}/source/amf-capabilities.cpp"
+    "${PROJECT_SOURCE_DIR}/source/amf-encoder.cpp"
+    "${PROJECT_SOURCE_DIR}/source/amf-encoder-h264.cpp"
+    "${PROJECT_SOURCE_DIR}/source/enc-h264.cpp"
+    "${PROJECT_SOURCE_DIR}/source/amf-encoder-h265.cpp"
+    "${PROJECT_SOURCE_DIR}/source/enc-h265.cpp"
+    "${PROJECT_SOURCE_DIR}/source/api-base.cpp"
+    "${PROJECT_SOURCE_DIR}/source/api-host.cpp"
+    "${PROJECT_SOURCE_DIR}/source/api-opengl.cpp"
+    "${PROJECT_SOURCE_DIR}/source/utility.cpp"
+    "${PROJECT_SOURCE_DIR}/source/plugin.cpp")
+set(PROJECT_DATA "${PROJECT_SOURCE_DIR}/resources/locale/en-US.ini" "${PROJECT_SOURCE_DIR}/LICENSE")
+set(PROJECT_LIBRARIES version winmm)
+
+if(WIN32) # Windows Only
+  list(APPEND PROJECT_HEADERS "include/api-d3d9.hpp" "include/api-d3d11.hpp")
+  list(APPEND PROJECT_SOURCES "source/api-d3d9.cpp" "source/api-d3d11.cpp" "${PROJECT_BINARY_DIR}/cmake/version.rc")
+endif()
+
+# Source Grouping
+source_group("Data Files" FILES ${enc-amf_DATA})
+
+# ######################################################################################################################
+# Target
+# ######################################################################################################################
+
+add_library(${PROJECT_NAME} MODULE ${PROJECT_HEADERS} ${PROJECT_SOURCES} ${PROJECT_DATA})
+if(${PropertyPrefix}OBS_NATIVE)
+  set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER "plugins/enc-amf")
+endif()
+
+# Include Directories
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC "${PROJECT_BINARY_DIR}/include" "${PROJECT_SOURCE_DIR}/include" "${PROJECT_SOURCE_DIR}/AMF/amf/public/include"
+  PRIVATE "${PROJECT_BINARY_DIR}/source" "${PROJECT_SOURCE_DIR}/source" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}"
+          "${CMAKE_SOURCE_DIR}")
+
+# OBS Studio
+if(${PropertyPrefix}OBS_NATIVE)
+  target_link_libraries(${PROJECT_NAME} libobs)
+elseif(${PropertyPrefix}OBS_REFERENCE)
+  target_include_directories(${PROJECT_NAME} PRIVATE "${OBS_STUDIO_DIR}/libobs")
+  target_link_libraries(${PROJECT_NAME} "${LIBOBS_LIB}")
+elseif(${PropertyPrefix}OBS_PACKAGE)
+  target_include_directories(${PROJECT_NAME} PRIVATE "${OBS_STUDIO_DIR}/include")
+  target_link_libraries(${PROJECT_NAME} libobs)
+elseif(${PropertyPrefix}OBS_DOWNLOAD)
+  target_link_libraries(${PROJECT_NAME} libobs)
+endif()
+
+# Link Libraries
+target_link_libraries(${PROJECT_NAME} "${PROJECT_LIBRARIES}")
+
+# Definitions
+if(WIN32)
+  target_compile_definitions(
+    ${PROJECT_NAME}
+    PRIVATE _CRT_SECURE_NO_WARNINGS
+            # windows.h
+            WIN32_LEAN_AND_MEAN
+            NOGPICAPMASKS
+            NOVIRTUALKEYCODES
+            # NOWINMESSAGES
+            NOWINSTYLES
+            NOSYSMETRICS
+            NOMENUS
+            NOICONS
+            NOKEYSTATES
+            NOSYSCOMMANDS
+            NORASTEROPS
+            NOSHOWWINDOW
+            NOATOM
+            NOCLIPBOARD
+            NOCOLOR
+            NOCTLMGR
+            NODRAWTEXT
+            # NOGDI
+            NOKERNEL
+            # NOUSER NONLS
+            NOMB
+            NOMEMMGR
+            NOMETAFILE
+            NOMINMAX
+            # NOMSG
+            NOOPENFILE
+            NOSCROLL
+            NOSERVICE
+            NOSOUND
+            # NOTEXTMETRIC
+            NOWH
+            NOWINOFFSETS
+            NOCOMM
+            NOKANJI
+            NOHELP
+            NOPROFILER
+            NODEFERWINDOWPOS
+            NOMCX
+            NOIME
+            NOMDI
+            NOINOUT)
+endif()
+
+# File Version
+if(WIN32)
+  set_target_properties(
+    ${PROJECT_NAME}
+    PROPERTIES VERSION
+               ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_TWEAK}
+               SOVERSION
+               ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_TWEAK})
+else()
+  set_target_properties(
+    ${PROJECT_NAME}
+    PROPERTIES VERSION
+               ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_TWEAK}
+               SOVERSION
+               ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_TWEAK})
+endif()
+
+# CPPCheck
+if(NOT ${PropertyPrefix}OBS_NATIVE)
+  set(excludes)
+  list(APPEND excludes "${PROJECT_SOURCE_DIR}/AMF")
+  if(${PropertyPrefix}OBS_REFERENCE)
+    list(APPEND excludes "${OBS_STUDIO_DIR}/libobs")
+  elseif(${PropertyPrefix}OBS_PACKAGE)
+    list(APPEND excludes "${OBS_STUDIO_DIR}/libobs")
+  elseif(${PropertyPrefix}OBS_DOWNLOAD)
+    list(APPEND excludes "${libobs_SOURCE_DIR}")
+  endif()
+
+  cppcheck(EXCLUDE ${excludes})
+  cppcheck_add_project(${PROJECT_NAME})
+endif()
+
+# ######################################################################################################################
+# Installation
+# ######################################################################################################################
+
+if(${PropertyPrefix}OBS_NATIVE)
+  install_obs_plugin_with_data(${PROJECT_NAME} resources)
+else()
+  install(
+    TARGETS ${PROJECT_NAME}
+    RUNTIME DESTINATION "./obs-plugins/${BITS}bit/" COMPONENT Runtime
+    LIBRARY DESTINATION "./obs-plugins/${BITS}bit/" COMPONENT Runtime)
+  if(MSVC)
+    install(
+      FILES $<TARGET_PDB_FILE:${PROJECT_NAME}>
+      DESTINATION "./obs-plugins/${BITS}bit/"
+      OPTIONAL)
+  endif()
+
+  install(DIRECTORY "${PROJECT_SOURCE_DIR}/resources/" DESTINATION "./data/obs-plugins/${PROJECT_NAME}/")
+
+  if("${CMAKE_PACKAGE_SUFFIX_OVERRIDE}" STREQUAL "")
+    set(PackageFullName "${CMAKE_PACKAGE_PREFIX}/${CMAKE_PACKAGE_NAME}-${PROJECT_VERSION}")
+  else()
+    set(PackageFullName "${CMAKE_PACKAGE_PREFIX}/${CMAKE_PACKAGE_NAME}-${CMAKE_PACKAGE_SUFFIX_OVERRIDE}")
+  endif()
+
+  add_custom_target(
+    PACKAGE_7Z
+    ${CMAKE_COMMAND}
+    -E
+    tar
+    cfv
+    "${PackageFullName}.7z"
+    --format=7zip
+    --
+    "${CMAKE_INSTALL_PREFIX}/obs-plugins"
+    "${CMAKE_INSTALL_PREFIX}/data"
+    WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}")
+  add_custom_target(
+    PACKAGE_ZIP
+    ${CMAKE_COMMAND}
+    -E
+    tar
+    cfv
+    "${PackageFullName}.zip"
+    --format=zip
+    --
+    "${CMAKE_INSTALL_PREFIX}/obs-plugins"
+    "${CMAKE_INSTALL_PREFIX}/data"
+    WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}")
+endif()
+
+# ######################################################################################################################
+# Child Projects
+# ######################################################################################################################
+
+# Sub Project
+add_subdirectory(amf-test)

--- a/cmake/windows/obs-module.rc.in
+++ b/cmake/windows/obs-module.rc.in
@@ -1,0 +1,24 @@
+1 VERSIONINFO
+FILEVERSION ${_VERSION_MAJOR},${_VERSION_MINOR},${_VERSION_PATCH},0
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904B0"
+    BEGIN
+      VALUE "CompanyName", "Xaymar"
+      VALUE "FileDescription", "OBS Studio AMD Encoder"
+      VALUE "FileVersion", "${_VERSION_MAJOR}.${_VERSION_MINOR}.${_VERSION_PATCH}"
+      VALUE "ProductName", "OBS Studio AMD Encoder"
+      VALUE "ProductVersion", "${_VERSION_MAJOR}.${_VERSION_MINOR}.${_VERSION_PATCH}"
+      VALUE "Comments", "Advanced Micro Devices, AMD, AMD Ryzen, Ryzen, AMD Radeon and Radeon are Trademarks of Advanced Micro Devices."
+      VALUE "LegalCopyright", "Xaymar © 2016 - 2018"
+      VALUE "InternalName", "OBS Studio AMD Encoder"
+      VALUE "OriginalFilename", "OBS Studio AMD Encoder"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0409, 0x04B0
+  END
+END


### PR DESCRIPTION
### Description
This PR updates the CMake build files to be compatible with the build system 3.0 update on the main repository.

### Motivation and Context

* The current build script is retained as the "legacy" script (which will still be used to generate build projects on Linux and macOS)
* The new build script is used for macOS builds by default at first

More information shall be available in the pull request on the main repository.

Note: This PR needs to be merged first, then the associated commit hash updated for the obs-amd-encoder submodule at obs-studio.

### How Has This Been Tested?
* New build scripts were tested as part of the overall update on macOS 13, Ubuntu 22.10, and Windows 11.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
