### PR TITLE
Fix compilation errors with strict MSVC settings

### DIFF
--- a/include/api-d3d11.hpp
+++ b/include/api-d3d11.hpp
@@ -18,7 +18,7 @@
  */
 
 #pragma once
-#include <atlutil.h>
+#include <atlcomcli.h>
 #include <d3d11.h>
 #include <dxgi.h>
 #include <map>

--- a/include/api-d3d9.hpp
+++ b/include/api-d3d9.hpp
@@ -18,7 +18,7 @@
  */
 
 #pragma once
-#include <atlutil.h>
+#include <atlcomcli.h>
 #include <d3d9.h>
 #include "api-base.hpp"
 

--- a/include/plugin.hpp
+++ b/include/plugin.hpp
@@ -37,11 +37,11 @@ extern "C" {
 
 #ifndef LITE_OBS
 #define PLOG(level, ...) blog(level, "[AMF] " __VA_ARGS__)
-#define PLOG_ERROR(format, ...) PLOG(LOG_ERROR, format, __VA_ARGS__)
+#define PLOG_ERROR(format, ...) PLOG(LOG_ERROR, format, ##__VA_ARGS__)
 #define PLOG_VAR(var) var
 #else
 #define PLOG(...) (void)0
-#define PLOG_ERROR(format, ...) printf("[AMF] " format "\n", __VA_ARGS__)
+#define PLOG_ERROR(format, ...) printf("[AMF] " format "\n", ##__VA_ARGS__)
 #define PLOG_VAR(var)
 #endif
 #define PLOG_WARNING(...) PLOG(LOG_WARNING, __VA_ARGS__)

--- a/source/utility.cpp
+++ b/source/utility.cpp
@@ -801,7 +801,7 @@ Plugin::AMD::ProfileLevel Utility::H265ProfileLevel(std::pair<uint32_t, uint32_t
 											  level(ProfileLevel::L52, levelRestriction(8912896, 1069547520)),
 											  level(ProfileLevel::L60, levelRestriction(35651584, 1069547520)),
 											  level(ProfileLevel::L61, levelRestriction(35651584, 2139095040)),
-											  level(ProfileLevel::L62, levelRestriction(35651584, 4278190080)),
+											  level(ProfileLevel::L62, levelRestriction(35651584, 4278190080u)),
 											  level((ProfileLevel)-1, levelRestriction(0, 0))};
 
 	uint32_t samples     = resolution.first * resolution.second;


### PR DESCRIPTION
### Description

Allow building of the plugin with #8377 applied.

### Motivation and Context

For some reason we still compile this thing so I guess I can't just make our build fail.

### How Has This Been Tested?

Built locally, worked.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
