### PR TITLE
cmake: Fix version generation for included header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,10 @@ target_sources(
 target_include_directories(enc-amf PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include"
                                            "${CMAKE_CURRENT_SOURCE_DIR}/AMF/amf/public/include")
 
-set(_VERSION_MAJOR 2)
-set(_VERSION_MINOR 8)
-set(_VERSION_PATCH 0)
+set(PROJECT_VERSION_MAJOR 2)
+set(PROJECT_VERSION_MINOR 8)
+set(PROJECT_VERSION_PATCH 0)
+set(PROJECT_VERSION_TWEAK 0)
 
 configure_file(include/version.hpp.in version.hpp)
 target_sources(enc-amf PRIVATE version.hpp)


### PR DESCRIPTION
### Description
Fix generation of version header when CMake 3.0 variant is used.

### Motivation and Context
The generated version header file relies on project version variables which CMake only generates when an actual `project` exists (which was removed in the update as only the main project `obs-studio` exists).

### How Has This Been Tested?
Tested compilation on Windows 11 with updated CMake file.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
