### PR TITLE
cmake: Fix version generation for Windows rc file

### DIFF
--- a/cmake/windows/obs-module.rc.in
+++ b/cmake/windows/obs-module.rc.in
@@ -1,5 +1,5 @@
 1 VERSIONINFO
-FILEVERSION ${_VERSION_MAJOR},${_VERSION_MINOR},${_VERSION_PATCH},0
+FILEVERSION ${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},${PROJECT_VERSION_PATCH},0
 BEGIN
   BLOCK "StringFileInfo"
   BEGIN
@@ -7,9 +7,9 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xaymar"
       VALUE "FileDescription", "OBS Studio AMD Encoder"
-      VALUE "FileVersion", "${_VERSION_MAJOR}.${_VERSION_MINOR}.${_VERSION_PATCH}"
+      VALUE "FileVersion", "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
       VALUE "ProductName", "OBS Studio AMD Encoder"
-      VALUE "ProductVersion", "${_VERSION_MAJOR}.${_VERSION_MINOR}.${_VERSION_PATCH}"
+      VALUE "ProductVersion", "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
       VALUE "Comments", "Advanced Micro Devices, AMD, AMD Ryzen, Ryzen, AMD Radeon and Radeon are Trademarks of Advanced Micro Devices."
       VALUE "LegalCopyright", "Xaymar © 2016 - 2018"
       VALUE "InternalName", "OBS Studio AMD Encoder"


### PR DESCRIPTION
### Description
Fixes version generation for the Windows rc file, which is required for a successful build.

### Motivation and Context
Fix builds with updated Windows CMake scripts.

### How Has This Been Tested?
* Tested in interactive session on Windows-based GitHub Actions runner.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
