### PR TITLE
cmake: Handle copy and install of locale files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,35 @@ target_sources(
 target_include_directories(enc-amf PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include"
                                            "${CMAKE_CURRENT_SOURCE_DIR}/AMF/amf/public/include")
 
+# Since the locale files are in "resources" instead of "data", handle locale files install/copy here.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/resources")
+  file(GLOB_RECURSE data_files "${CMAKE_CURRENT_SOURCE_DIR}/resources/*")
+  foreach(data_file IN LISTS data_files)
+    cmake_path(RELATIVE_PATH data_file BASE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/resources/" OUTPUT_VARIABLE
+               relative_path)
+    cmake_path(GET relative_path PARENT_PATH relative_path)
+    target_sources(enc-amf PRIVATE "${data_file}")
+    source_group("Resources/${relative_path}" FILES "${data_file}")
+  endforeach()
+
+  set(target_destination "${OBS_DATA_DESTINATION}/obs-plugins/enc-amf")
+
+  install(
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/resources/"
+    DESTINATION "${target_destination}"
+    USE_SOURCE_PERMISSIONS
+    COMPONENT Runtime)
+
+  add_custom_command(
+    TARGET enc-amf
+    POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${OBS_OUTPUT_DIR}/$<CONFIG>/${target_destination}"
+    COMMAND "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/resources"
+            "${OBS_OUTPUT_DIR}/$<CONFIG>/${target_destination}"
+    COMMENT "Copy enc-amf resources to data directory"
+    VERBATIM)
+endif()
+
 set(PROJECT_VERSION_MAJOR 2)
 set(PROJECT_VERSION_MINOR 8)
 set(PROJECT_VERSION_PATCH 0)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Copy and install the locale files for enc-amf.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want plugins to not break.

Normally, the new OBS CMake helpers would handle this, but those expect locale files to be in `data` instead of `resources`. We considered moving the locale files from `resources` to `data`, but other things, such as https://github.com/obsproject/obs-crowdin-sync/, have special handling for enc-amf, and I didn't want to worry about what else would break.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built locally.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
